### PR TITLE
Adding Intel Gaudi support

### DIFF
--- a/llm-service/helm/templates/inference-service.yaml
+++ b/llm-service/helm/templates/inference-service.yaml
@@ -2,12 +2,8 @@
 {{- $models := include "llm-service.mergeModels" . | fromJson }}
 {{- range $key, $model := $models }}
 {{- if and $model.enabled (not $model.url) }}
-{{- /* Device compatibility validation */ -}}
-{{- if $model.incompatibleDevices }}
-  {{- if has $root.Values.device $model.incompatibleDevices }}
-    {{- fail (printf "ERROR: Model '%s' is not compatible with device '%s'. This model is incompatible with: %s. Please use a different device or model." $key $root.Values.device ($model.incompatibleDevices | join ", ")) }}
-  {{- end }}
-{{- end }}
+{{- $modelDevice := $model.device | default $root.Values.device }}
+{{- $deviceConfig := index $root.Values.deviceConfigs $modelDevice }}
 ---
 apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
@@ -24,6 +20,7 @@ metadata:
   labels:
     opendatahub.io/dashboard: "true"
     networking.knative.dev/visibility: "cluster-local"
+    device: {{ $modelDevice }}
 spec:
   predictor:
     maxReplicas: {{ $model.maxReplicas | default 1 }}
@@ -34,8 +31,7 @@ spec:
       name: ""
       {{- if hasKey $model "resources" }}
       resources:
-        {{- if or (eq $root.Values.device "gpu") (eq $root.Values.device "hpu") }}
-          {{- $deviceConfig := index $root.Values.deviceConfigs $root.Values.device }}
+        {{- if or (eq $modelDevice "gpu") (eq $modelDevice "hpu") }}
           {{- $acceleratorType := $deviceConfig.acceleratorType }}
           {{- $acceleratorCount := $model.accelerators | default "1" }}
           {{- $customResources := $model.resources | deepCopy }}
@@ -51,11 +47,10 @@ spec:
         {{- else }}
           {{- toYaml $model.resources | nindent 8 }}
         {{- end }}
-      {{- else if or (eq $root.Values.device "gpu") (eq $root.Values.device "hpu") }}
+      {{- else if or (eq $modelDevice "gpu") (eq $modelDevice "hpu") }}
       resources:
-      {{- $deviceConfig := index $root.Values.deviceConfigs $root.Values.device }}
-      {{- $acceleratorType := $deviceConfig.acceleratorType }}
-      {{- $acceleratorCount := $model.accelerators | default "1" }}
+        {{- $acceleratorType := $deviceConfig.acceleratorType }}
+        {{- $acceleratorCount := $model.accelerators | default "1" }}
         limits:
           cpu: "2"
           memory: 8Gi
@@ -89,7 +84,7 @@ spec:
           ephemeral-storage: {{ $model.storageSize | default "50Gi" }}
           {{- end }}
       {{- end }}
-      runtime: {{ $root.Values.servingRuntime.name }}
+      runtime: {{ $root.Values.servingRuntime.name }}-{{ $modelDevice }}
       args:
       - --model
       - {{ $model.id }}
@@ -105,8 +100,8 @@ spec:
     {{- $tolerations := list }}
     {{- if hasKey $model "tolerations" }}
       {{- $tolerations = $model.tolerations }}
-    {{- else if hasKey $root.Values.deviceConfigs $root.Values.device }}
-      {{- $tolerations = (index $root.Values.deviceConfigs $root.Values.device).tolerations }}
+    {{- else if $deviceConfig.tolerations }}
+      {{- $tolerations = $deviceConfig.tolerations }}
     {{- end }}
     {{- if $tolerations }}
     tolerations:
@@ -114,3 +109,4 @@ spec:
     {{- end }}
 {{- end }}
 {{- end }}
+

--- a/llm-service/helm/templates/inference-service.yaml
+++ b/llm-service/helm/templates/inference-service.yaml
@@ -2,6 +2,12 @@
 {{- $models := include "llm-service.mergeModels" . | fromJson }}
 {{- range $key, $model := $models }}
 {{- if and $model.enabled (not $model.url) }}
+{{- /* Device compatibility validation */ -}}
+{{- if $model.incompatibleDevices }}
+  {{- if has $root.Values.device $model.incompatibleDevices }}
+    {{- fail (printf "ERROR: Model '%s' is not compatible with device '%s'. This model is incompatible with: %s. Please use a different device or model." $key $root.Values.device ($model.incompatibleDevices | join ", ")) }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
@@ -26,21 +32,62 @@ spec:
       modelFormat:
         name: vLLM
       name: ""
-      resources:
       {{- if hasKey $model "resources" }}
-      {{- toYaml $model.resources | nindent 8 }}
-      {{- else }}
-      {{- if eq $root.Values.device "gpu" }}
+      resources:
+        {{- if or (eq $root.Values.device "gpu") (eq $root.Values.device "hpu") }}
+          {{- $deviceConfig := index $root.Values.deviceConfigs $root.Values.device }}
+          {{- $acceleratorType := $deviceConfig.acceleratorType }}
+          {{- $acceleratorCount := $model.accelerators | default "1" }}
+          {{- $customResources := $model.resources | deepCopy }}
+          {{- if $acceleratorType }}
+            {{- if not (hasKey $customResources.limits $acceleratorType) }}
+              {{- $_ := set $customResources.limits $acceleratorType $acceleratorCount }}
+            {{- end }}
+            {{- if not (hasKey $customResources.requests $acceleratorType) }}
+              {{- $_ := set $customResources.requests $acceleratorType $acceleratorCount }}
+            {{- end }}
+          {{- end }}
+          {{- toYaml $customResources | nindent 8 }}
+        {{- else }}
+          {{- toYaml $model.resources | nindent 8 }}
+        {{- end }}
+      {{- else if or (eq $root.Values.device "gpu") (eq $root.Values.device "hpu") }}
+      resources:
+      {{- $deviceConfig := index $root.Values.deviceConfigs $root.Values.device }}
+      {{- $acceleratorType := $deviceConfig.acceleratorType }}
+      {{- $acceleratorCount := $model.accelerators | default "1" }}
         limits:
           cpu: "2"
           memory: 8Gi
-          nvidia.com/gpu: "1"
+          {{- if $acceleratorType }}
+          {{ $acceleratorType }}: {{ $acceleratorCount | quote }}
+          {{- end }}
+          {{- if $model.storageSize }}
+          ephemeral-storage: {{ $model.storageSize | default "50Gi" }}
+          {{- end }}
         requests:
           cpu: "1"
           memory: 4Gi
-          nvidia.com/gpu: "1"
+          {{- if $acceleratorType }}
+          {{ $acceleratorType }}: {{ $acceleratorCount | quote }}
+          {{- end }}
+          {{- if $model.storageSize }}
           ephemeral-storage: {{ $model.storageSize | default "50Gi" }}
-      {{- end }}
+          {{- end }}
+      {{- else }}
+      resources:
+        limits:
+          cpu: "2"
+          memory: 8Gi
+          {{- if $model.storageSize }}
+          ephemeral-storage: {{ $model.storageSize | default "50Gi" }}
+          {{- end }}
+        requests:
+          cpu: "1"
+          memory: 4Gi
+          {{- if $model.storageSize }}
+          ephemeral-storage: {{ $model.storageSize | default "50Gi" }}
+          {{- end }}
       {{- end }}
       runtime: {{ $root.Values.servingRuntime.name }}
       args:
@@ -55,13 +102,15 @@ spec:
       env:
         {{- toYaml . | nindent 6 }}
       {{- end }}
-    tolerations:
+    {{- $tolerations := list }}
     {{- if hasKey $model "tolerations" }}
-    {{- toYaml $model.tolerations | nindent 4 }}
-    {{- else }}
-    - key: nvidia.com/gpu
-      effect: NoSchedule
-      operator: Exists
+      {{- $tolerations = $model.tolerations }}
+    {{- else if hasKey $root.Values.deviceConfigs $root.Values.device }}
+      {{- $tolerations = (index $root.Values.deviceConfigs $root.Values.device).tolerations }}
+    {{- end }}
+    {{- if $tolerations }}
+    tolerations:
+    {{- toYaml $tolerations | nindent 4 }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/llm-service/helm/templates/serving-runtime.yaml
+++ b/llm-service/helm/templates/serving-runtime.yaml
@@ -1,23 +1,35 @@
+{{- $root := . }}
+{{- $models := include "llm-service.mergeModels" . | fromJson }}
+{{- $usedDevices := dict }}
+{{- range $key, $model := $models }}
+  {{- if $model.enabled }}
+    {{- $modelDevice := $model.device | default $root.Values.device }}
+    {{- $_ := set $usedDevices $modelDevice true }}
+  {{- end }}
+{{- end }}
+{{- range $device, $_ := $usedDevices }}
+{{- $deviceConfig := index $root.Values.deviceConfigs $device }}
 ---
 apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
 metadata:
-  name: {{ .Values.servingRuntime.name }}
+  name: {{ $root.Values.servingRuntime.name }}-{{ $device }}
   annotations:
-    openshift.io/display-name: {{ .Values.servingRuntime.name }}
-    {{- if and (hasKey .Values.deviceConfigs .Values.device) (index .Values.deviceConfigs .Values.device).recommendedAccelerators }}
-    opendatahub.io/recommended-accelerators: '{{ (index .Values.deviceConfigs .Values.device).recommendedAccelerators | toJson }}'
+    openshift.io/display-name: {{ $root.Values.servingRuntime.name }}-{{ $device }}
+    {{- if $deviceConfig.recommendedAccelerators }}
+    opendatahub.io/recommended-accelerators: '{{ $deviceConfig.recommendedAccelerators | toJson }}'
     {{- end }}
     opendatahub.io/apiProtocol: REST
-    opendatahub.io/template-display-name: vLLM ServingRuntime for KServe
-    opendatahub.io/template-name: vllm-runtime
+    opendatahub.io/template-display-name: vLLM ServingRuntime for KServe ({{ $device | upper }})
+    opendatahub.io/template-name: vllm-runtime-{{ $device }}
   labels:
     opendatahub.io/dashboard: "true"
+    device: {{ $device }}
 spec:
   annotations:
     prometheus.io/path: /metrics
     prometheus.io/port: "8080"
-    serving.knative.dev/progress-deadline: {{ .Values.servingRuntime.knativeTimeout }}
+    serving.knative.dev/progress-deadline: {{ $root.Values.servingRuntime.knativeTimeout }}
   containers:
   - command:
     - python3
@@ -28,22 +40,22 @@ spec:
     - "8080"
     - --download-dir
     - /vllm/model
-    {{-  with .Values.servingRuntime.env }}
+    {{-  with $root.Values.servingRuntime.env }}
     env:
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if eq .Values.device "gpu" }}
-    image: {{ .Values.servingRuntime.gpuImage }}
-    {{- else if eq .Values.device "hpu" }}
-    image: {{ .Values.servingRuntime.hpuImage }}
+    {{- if eq $device "gpu" }}
+    image: {{ $root.Values.servingRuntime.gpuImage }}
+    {{- else if eq $device "hpu" }}
+    image: {{ $root.Values.servingRuntime.hpuImage }}
     {{- else }}
-    image: {{ .Values.servingRuntime.cpuImage }}
+    image: {{ $root.Values.servingRuntime.cpuImage }}
     {{- end }}
     name: kserve-container
     ports:
     - containerPort: 8080
       protocol: TCP
-    {{- with .Values.servingRuntime.volumeMounts }}
+    {{- with $root.Values.servingRuntime.volumeMounts }}
     volumeMounts:
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -51,7 +63,8 @@ spec:
   supportedModelFormats:
   - autoSelect: true
     name: vLLM
-  {{- with .Values.servingRuntime.volumes }}
+  {{- with $root.Values.servingRuntime.volumes }}
   volumes:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/llm-service/helm/templates/serving-runtime.yaml
+++ b/llm-service/helm/templates/serving-runtime.yaml
@@ -44,13 +44,7 @@ spec:
     env:
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if eq $device "gpu" }}
-    image: {{ $root.Values.servingRuntime.gpuImage }}
-    {{- else if eq $device "hpu" }}
-    image: {{ $root.Values.servingRuntime.hpuImage }}
-    {{- else }}
-    image: {{ $root.Values.servingRuntime.cpuImage }}
-    {{- end }}
+    image: {{ index $root.Values.deviceConfigs $device "image" }}
     name: kserve-container
     ports:
     - containerPort: 8080

--- a/llm-service/helm/templates/serving-runtime.yaml
+++ b/llm-service/helm/templates/serving-runtime.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ .Values.servingRuntime.name }}
   annotations:
     openshift.io/display-name: {{ .Values.servingRuntime.name }}
-    {{- with .Values.servingRuntime.recommendedAccelerators }}
-    opendatahub.io/recommended-accelerators: '{{ . | toJson }}'
+    {{- if and (hasKey .Values.deviceConfigs .Values.device) (index .Values.deviceConfigs .Values.device).recommendedAccelerators }}
+    opendatahub.io/recommended-accelerators: '{{ (index .Values.deviceConfigs .Values.device).recommendedAccelerators | toJson }}'
     {{- end }}
     opendatahub.io/apiProtocol: REST
     opendatahub.io/template-display-name: vLLM ServingRuntime for KServe
@@ -34,6 +34,8 @@ spec:
     {{- end }}
     {{- if eq .Values.device "gpu" }}
     image: {{ .Values.servingRuntime.gpuImage }}
+    {{- else if eq .Values.device "hpu" }}
+    image: {{ .Values.servingRuntime.hpuImage }}
     {{- else }}
     image: {{ .Values.servingRuntime.cpuImage }}
     {{- end }}

--- a/llm-service/helm/values.yaml
+++ b/llm-service/helm/values.yaml
@@ -1,13 +1,35 @@
 device: gpu
 rawDeploymentMode: true
 
+# Device-specific configurations for tolerations and accelerators
+deviceConfigs:
+  gpu:
+    tolerations:
+      - key: nvidia.com/gpu
+        effect: NoSchedule
+        operator: Exists
+    recommendedAccelerators:
+      - nvidia.com/gpu
+    acceleratorType: nvidia.com/gpu
+  hpu:
+    tolerations:
+      - key: habana.ai/gaudi
+        effect: NoSchedule
+        operator: Exists
+    recommendedAccelerators:
+      - habana.ai/gaudi
+    acceleratorType: habana.ai/gaudi
+  cpu:
+    tolerations: []
+    recommendedAccelerators: []
+    acceleratorType: null
+
 servingRuntime:
   name: vllm-serving-runtime
   knativeTimeout: 60m
   gpuImage: quay.io/ecosystem-appeng/vllm:openai-v0.9.2
   cpuImage: quay.io/ecosystem-appeng/vllm:cpu-v0.9.2
-  recommendedAccelerators:
-    - nvidia.com/gpu
+  hpuImage: quay.io/modh/vllm:vllm-gaudi-v2-22-on-push-jgj5q-build-container
   env:
     - name: HOME
       value: /vllm
@@ -48,6 +70,13 @@ models:
     #   - key: nvidia.com/gpu
     #     effect: NoSchedule
     #     operator: Exists
+    resources:
+      limits:
+        cpu: "2"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 16Gi
     args:
       - --enable-auto-tool-choice
       - --chat-template
@@ -55,18 +84,36 @@ models:
       - --tool-call-parser
       - llama3_json
       - --max-model-len
-      - "30544"
+      - "14336"
+      - --max-num-seqs
+      - "32"
 
   llama-guard-3-1b:
     id: meta-llama/Llama-Guard-3-1B
     enabled: false
+    resources:
+      limits:
+        cpu: "2"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 16Gi
     args:
       - --max-model-len
       - "14336"
+      - --max-num-seqs
+      - "32"
 
   llama-3-2-3b-instruct:
     id: meta-llama/Llama-3.2-3B-Instruct
     enabled: false
+    resources:
+      limits:
+        cpu: "2"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 16Gi
     args:
       - --enable-auto-tool-choice
       - --chat-template
@@ -74,24 +121,41 @@ models:
       - --tool-call-parser
       - llama3_json
       - --max-model-len
-      - "30544"
+      - "14336"
+      - --max-num-seqs
+      - "32"
 
   llama-guard-3-8b:
     id: meta-llama/Llama-Guard-3-8B
     enabled: false
+    resources:
+      limits:
+        cpu: "2"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 16Gi
     args:
       - --max-model-len
       - "14336"
+      - --max-num-seqs
+      - "32"
 
   llama-3-1-8b-instruct:
     id: meta-llama/Llama-3.1-8B-Instruct
     enabled: false
     resources:
       limits:
-        nvidia.com/gpu: "1"
+        cpu: "2"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 16Gi
     args:
       - --max-model-len
       - "14336"
+      - --max-num-seqs
+      - "32"
       - --enable-auto-tool-choice
       - --chat-template
       - /chat-templates/tool_chat_template_llama3.2_json.jinja
@@ -102,9 +166,37 @@ models:
     id: meta-llama/Llama-3.3-70B-Instruct
     enabled: false
     storageSize: 150Gi
+    accelerators: "4"  # Number of accelerators needed different than 1
     resources:
       limits:
-        nvidia.com/gpu: "4"
+        cpu: "2"
+        memory: 300Gi
+      requests:
+        cpu: "1"
+        memory: 200Gi
+    args:
+      - --tensor-parallel-size
+      - "4"
+      - --gpu-memory-utilization
+      - "0.95"
+      - --max-num-batched-tokens
+      - "131074"
+      - --max-num-seqs
+      - "32"
+      - --enable-auto-tool-choice
+      - --chat-template
+      - /chat-templates/tool_chat_template_llama3.2_json.jinja
+      - --tool-call-parser
+      - llama3_json
+      - --swap-space
+      - "32"
+
+  llama-3-3-70b-instruct-quantization-fp8:
+    id: meta-llama/Llama-3.3-70B-Instruct
+    enabled: false
+    incompatibleDevices: ["hpu"]  # Device compatibility - quantized model doesn't work with HPU
+    storageSize: 150Gi
+    accelerators: "4"
     args:
       - --tensor-parallel-size
       - "4"
@@ -125,6 +217,7 @@ models:
   llama-3-2-1b-instruct-quantized:
     id: RedHatAI/Llama-3.2-1B-Instruct-quantized.w8a8
     enabled: false
+    incompatibleDevices: ["hpu"]
     args:
       - --gpu-memory-utilization
       - "0.4"
@@ -140,6 +233,7 @@ models:
 
   qwen-2-5-vl-3b-instruct:
     id: Qwen/Qwen2.5-VL-3B-Instruct
+    incompatibleDevices: ["hpu"]
     args:
       - --max-model-len
       - "30544"

--- a/llm-service/helm/values.yaml
+++ b/llm-service/helm/values.yaml
@@ -1,4 +1,4 @@
-device: gpu
+device: gpu  # Default device for models that don't specify one
 rawDeploymentMode: true
 
 # Device-specific configurations for tolerations and accelerators
@@ -64,6 +64,7 @@ models:
   llama-3-2-1b-instruct:
     id: meta-llama/Llama-3.2-1B-Instruct
     enabled: false
+    device: hpu  # Can be gpu, hpu, or cpu - defaults to global device if not specified
     # A default "nvidia.com/gpu" toleration is implemented in the
     # inference-service.yaml template and can be overriden as follows:
     # tolerations:
@@ -91,6 +92,7 @@ models:
   llama-guard-3-1b:
     id: meta-llama/Llama-Guard-3-1B
     enabled: false
+    device: hpu
     resources:
       limits:
         cpu: "2"
@@ -107,6 +109,7 @@ models:
   llama-3-2-3b-instruct:
     id: meta-llama/Llama-3.2-3B-Instruct
     enabled: false
+    device: hpu
     resources:
       limits:
         cpu: "2"
@@ -128,6 +131,7 @@ models:
   llama-guard-3-8b:
     id: meta-llama/Llama-Guard-3-8B
     enabled: false
+    device: hpu
     resources:
       limits:
         cpu: "2"
@@ -144,6 +148,7 @@ models:
   llama-3-1-8b-instruct:
     id: meta-llama/Llama-3.1-8B-Instruct
     enabled: false
+    device: hpu
     resources:
       limits:
         cpu: "2"
@@ -165,6 +170,7 @@ models:
   llama-3-3-70b-instruct:
     id: meta-llama/Llama-3.3-70B-Instruct
     enabled: false
+    device: hpu
     storageSize: 150Gi
     accelerators: "4"  # Number of accelerators needed different than 1
     resources:
@@ -194,7 +200,7 @@ models:
   llama-3-3-70b-instruct-quantization-fp8:
     id: meta-llama/Llama-3.3-70B-Instruct
     enabled: false
-    incompatibleDevices: ["hpu"]  # Device compatibility - quantized model doesn't work with HPU
+    device: gpu
     storageSize: 150Gi
     accelerators: "4"
     args:
@@ -217,7 +223,7 @@ models:
   llama-3-2-1b-instruct-quantized:
     id: RedHatAI/Llama-3.2-1B-Instruct-quantized.w8a8
     enabled: false
-    incompatibleDevices: ["hpu"]
+    device: gpu
     args:
       - --gpu-memory-utilization
       - "0.4"
@@ -233,7 +239,7 @@ models:
 
   qwen-2-5-vl-3b-instruct:
     id: Qwen/Qwen2.5-VL-3B-Instruct
-    incompatibleDevices: ["hpu"]
+    device: gpu
     args:
       - --max-model-len
       - "30544"

--- a/llm-service/helm/values.yaml
+++ b/llm-service/helm/values.yaml
@@ -4,6 +4,7 @@ rawDeploymentMode: true
 # Device-specific configurations for tolerations and accelerators
 deviceConfigs:
   gpu:
+    image: quay.io/ecosystem-appeng/vllm:openai-v0.9.2
     tolerations:
       - key: nvidia.com/gpu
         effect: NoSchedule
@@ -12,6 +13,7 @@ deviceConfigs:
       - nvidia.com/gpu
     acceleratorType: nvidia.com/gpu
   hpu:
+    image: quay.io/modh/vllm:vllm-gaudi-v2-22-on-push-jgj5q-build-container
     tolerations:
       - key: habana.ai/gaudi
         effect: NoSchedule
@@ -20,6 +22,7 @@ deviceConfigs:
       - habana.ai/gaudi
     acceleratorType: habana.ai/gaudi
   cpu:
+    image: quay.io/ecosystem-appeng/vllm:cpu-v0.9.2
     tolerations: []
     recommendedAccelerators: []
     acceleratorType: null
@@ -27,9 +30,6 @@ deviceConfigs:
 servingRuntime:
   name: vllm-serving-runtime
   knativeTimeout: 60m
-  gpuImage: quay.io/ecosystem-appeng/vllm:openai-v0.9.2
-  cpuImage: quay.io/ecosystem-appeng/vllm:cpu-v0.9.2
-  hpuImage: quay.io/modh/vllm:vllm-gaudi-v2-22-on-push-jgj5q-build-container
   env:
     - name: HOME
       value: /vllm


### PR DESCRIPTION
This PR adds support for Intel Gaudi HPUs alongside existing GPU and CPU support, implementing a device-specific configuration framework for the llm-service.

This llm-service has been validated as a dependency for [rh-ai-quickstart/RAG](https://github.com/rh-ai-quickstart/RAG/tree/main), with the intention of integrating it with RAG Kickstart as a next step.

Key Features:
- Add Intel Gaudi support with dedicated vLLM HPU container image
- Add deviceConfigs structure with device-specific tolerations and accelerator configurations
- Add device-specific accelerator types (nvidia.com/gpu, habana.ai/gaudi)
- Support custom accelerator counts per model via device agnostic 'accelerators' field
- Update model resources to handle vLLM warm-up on Gaudi HPU