### PR TITLE
ingestion-pipeline: sign database conditionally

### DIFF
--- a/ingestion-pipeline/helm/templates/_helpers.tpl
+++ b/ingestion-pipeline/helm/templates/_helpers.tpl
@@ -61,3 +61,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "ingestion-pipeline.signDatabase" -}}
+{{- if and (lookup "v1" "Namespace" "" "openshift-pipelines") (lookup "v1" "Namespace" "" "trusted-artifact-signer") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/ingestion-pipeline/helm/templates/db-validation-cronjob.yaml
+++ b/ingestion-pipeline/helm/templates/db-validation-cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "ingestion-pipeline.signDatabase" .) "true" }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -144,3 +145,4 @@ spec:
                       key: user
           restartPolicy: Never
           serviceAccountName: pipeline-runner-dspa
+{{- end }}

--- a/ingestion-pipeline/helm/templates/deployment.yaml
+++ b/ingestion-pipeline/helm/templates/deployment.yaml
@@ -87,6 +87,8 @@ spec:
             - name: LLAMA_STACK_AUTH_USER
               value: {{ .Values.authUser }}
           {{- end }}
+            - name: SIGN_DATABASE
+              value: {{ include "ingestion-pipeline.signDatabase" . | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}

--- a/ingestion-pipeline/helm/templates/rbac.yaml
+++ b/ingestion-pipeline/helm/templates/rbac.yaml
@@ -23,6 +23,8 @@ roleRef:
   kind: Role
   name: secret-writer
   apiGroup: rbac.authorization.k8s.io
+
+{{- if eq (include "ingestion-pipeline.signDatabase" .) "true" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -72,3 +74,4 @@ roleRef:
   kind: Role
   name: access-routes
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/ingestion-pipeline/src/ingestion_pipeline/pipelines/__init__.py
+++ b/ingestion-pipeline/src/ingestion_pipeline/pipelines/__init__.py
@@ -25,7 +25,8 @@ def add_pipeline(pipeline_name: str, source: str):
     pipeline_params = {
         "pipeline_name": pipeline_name,
         "llamastack_base_url": os.environ["LLAMASTACK_BASE_URL"],
-        "auth_user": os.getenv("LLAMA_STACK_AUTH_USER", "")
+        "auth_user": os.getenv("LLAMA_STACK_AUTH_USER", ""),
+        "sign_db": os.getenv("SIGN_DATABASE", "false")
     }
 
     with tempfile.NamedTemporaryFile(suffix=".yaml") as tmp:

--- a/ingestion-pipeline/src/ingestion_pipeline/pipelines/pipelines.py
+++ b/ingestion-pipeline/src/ingestion_pipeline/pipelines/pipelines.py
@@ -4,7 +4,7 @@ from typing import Optional
 from . import tasks
 
 
-def s3_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str):
+def s3_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str, sign_db: str):
     @dsl.pipeline(name="fetch-and-store-pipeline")
     def _pipeline():
         from kfp import kubernetes
@@ -34,12 +34,13 @@ def s3_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str):
         store_task.set_caching_options(False)
         pipeline_tasks.append(store_task)
 
-        provenance_task = tasks.generate_provenance(
-            input_dir=fetch_task.outputs["output_dir"]
-        )
-        provenance_task.set_caching_options(False)
-        provenance_task.after(store_task)
-        pipeline_tasks.append(provenance_task)
+        if sign_db == "true":
+            provenance_task = tasks.generate_provenance(
+                input_dir=fetch_task.outputs["output_dir"]
+            )
+            provenance_task.set_caching_options(False)
+            provenance_task.after(store_task)
+            pipeline_tasks.append(provenance_task)
 
         for task in pipeline_tasks:
             kubernetes.use_secret_as_env(
@@ -50,7 +51,7 @@ def s3_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str):
     return _pipeline
 
 
-def url_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str):
+def url_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str, sign_db: str):
     @dsl.pipeline(name="fetch-and-store-pipeline")
     def _pipeline():
         from kfp import kubernetes
@@ -80,7 +81,7 @@ def url_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str):
     return _pipeline
 
 
-def github_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str):
+def github_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str, sign_db: str):
     @dsl.pipeline(name="fetch-and-store-pipeline")
     def _pipeline():
         from kfp import kubernetes


### PR DESCRIPTION
Currently we try to sign the databases automatically at the end of an S3 pipeline. For this to work we need Openshift Pipelines and Openshift Trusted Artifact Signer.  This PR disables signing in case openshift-pipelines and trusted-artifact-signer namespaces do not exist in the cluster.