### PR TITLE
Enable DB signing via a flag

### DIFF
--- a/ingestion-pipeline/helm/templates/_helpers.tpl
+++ b/ingestion-pipeline/helm/templates/_helpers.tpl
@@ -61,11 +61,3 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
-
-{{- define "ingestion-pipeline.signDatabase" -}}
-{{- if and (lookup "v1" "Namespace" "" "openshift-pipelines") (lookup "v1" "Namespace" "" "trusted-artifact-signer") -}}
-true
-{{- else -}}
-false
-{{- end -}}
-{{- end -}}

--- a/ingestion-pipeline/helm/templates/db-validation-cronjob.yaml
+++ b/ingestion-pipeline/helm/templates/db-validation-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "ingestion-pipeline.signDatabase" .) "true" }}
+{{- if .Values.enableSigning }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/ingestion-pipeline/helm/templates/deployment.yaml
+++ b/ingestion-pipeline/helm/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
               value: {{ .Values.authUser }}
           {{- end }}
             - name: SIGN_DATABASE
-              value: {{ include "ingestion-pipeline.signDatabase" . | quote }}
+              value: {{ .Values.enableSigning | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}

--- a/ingestion-pipeline/helm/templates/rbac.yaml
+++ b/ingestion-pipeline/helm/templates/rbac.yaml
@@ -24,7 +24,7 @@ roleRef:
   name: secret-writer
   apiGroup: rbac.authorization.k8s.io
 
-{{- if eq (include "ingestion-pipeline.signDatabase" .) "true" }}
+{{- if .Values.enableSigning }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/ingestion-pipeline/helm/values.yaml
+++ b/ingestion-pipeline/helm/values.yaml
@@ -82,3 +82,6 @@ defaultPipeline:
       - "https://github.com/docling-project/docling/blob/main/tests/data/pdf/2206.01062.pdf"
 
 authUser: ""
+
+# generate provenance for the knowledge base
+enableSigning: false


### PR DESCRIPTION
GitOps does not contact the cluster when rendering the template. So instead of using the presence of namespaces to activate the feature, a new flag is added, controlled by the user.