### PR TITLE
feat: expose files API to support responses API

### DIFF
--- a/llama-stack/helm/templates/configmap.yaml
+++ b/llama-stack/helm/templates/configmap.yaml
@@ -19,6 +19,7 @@ data:
     - agents
     - datasetio
     - eval
+    - files
     - inference
     - safety
     - scoring
@@ -60,6 +61,14 @@ data:
           kvstore:
             type: sqlite
             db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter}/pgvector_registry.db
+      files:
+      - provider_id: meta-reference-files
+        provider_type: inline::localfs
+        config:
+          storage_dir: ${env.FILES_STORAGE_DIR:=/tmp/llama-stack-files}
+          metadata_store:
+            type: sqlite
+            db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter}/files_metadata.db
       safety:
       - provider_id: llama-guard
         provider_type: inline::llama-guard


### PR DESCRIPTION
The files API is needed to use the OpenAI repsonses API when using RAG databases.