### PR TITLE
Config otlp endpoint and service name

### DIFF
--- a/llama-stack/helm/templates/configmap.yaml
+++ b/llama-stack/helm/templates/configmap.yaml
@@ -115,8 +115,10 @@ data:
       - provider_id: meta-reference
         provider_type: inline::meta-reference
         config:
+          service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
           sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
-          sqlite_db_path: ${env.SQLITE_DB_PATH:=~/.llama/distributions/starter/trace_store.db}
+          sqlite_db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter}/trace_store.db
+          otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}
       tool_runtime:
       - provider_id: brave-search
         provider_type: remote::brave-search

--- a/llama-stack/helm/values.yaml
+++ b/llama-stack/helm/values.yaml
@@ -44,8 +44,10 @@ env:
     value: "4096"
   - name: VLLM_API_TOKEN
     value: fake
-  - name: OTEL_ENDPOINT
-    value: http://otel-collector-collector.observability-hub.svc.cluster.local:4318/v1/traces
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: http://otel-collector-collector.observability-hub.svc.cluster.local:4318
+  - name: OTEL_SERVICE_NAME
+    value: llama-stack
   - name: POSTGRES_USER
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
Allows Llama Stack to publish telemetry items to a remote OTLP collector.