### PR TITLE
feat: add standalone keycloak helm chart with pgvector dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ MCP server that exposes Oracle SQLcl capabilities to AI agents via Toolhive, ena
 - Integrates with Toolhive Operator v0.2.19 (CRDs v0.0.30 and operator managed as chart dependencies)
 - Orale connection managed via Kubernetes secrets and configurable service
 
+### 🔐 Security & Identity
+
+#### [Keycloak](./keycloak/README.md)
+Identity and access management solution providing authentication and authorization for AI applications. Supports OAuth2, OpenID Connect, and SAML protocols.
+
+**Key Features:**
+- Official Keycloak container images
+- Built-in PostgreSQL database (via pgvector subchart) or external database support
+- OpenShift Routes and Kubernetes Ingress support
+- Production-ready configuration with health checks and metrics
+- Flexible authentication and authorization policies
+
 ## Quick Start
 
 ### Prerequisites
@@ -278,6 +290,9 @@ Each chart can be deployed individually:
 helm install pgvector ./pgvector/helm
 helm install minio ./minio/helm
 helm install llm-service ./llm-service/helm
+helm install keycloak ./keycloak/helm \
+  --set admin.password=changeme \
+  --set pgvector.secret.password=changeme
 ```
 
 ### Chart Dependencies
@@ -292,11 +307,11 @@ version: 1.0.0
 
 dependencies:
   - name: pgvector
-    version: "0.1.0"
+    version: "0.5.1"
     repository: "file://../ai-architecture-charts/pgvector/helm"
   
   - name: minio
-    version: "0.1.0"
+    version: "0.5.0"
     repository: "file://../ai-architecture-charts/minio/helm"
   
   - name: llm-service
@@ -310,6 +325,10 @@ dependencies:
   - name: ingestion-pipeline
     version: "0.2.18"
     repository: "file://../ai-architecture-charts/ingestion-pipeline/helm"
+  
+  - name: keycloak
+    version: "1.0.0"
+    repository: "file://../ai-architecture-charts/keycloak/helm"
 ```
 
 ### Configuring Subcharts
@@ -355,6 +374,16 @@ ingestion-pipeline:
     S3:
       bucket_name: ai-documents
       endpoint_url: http://minio:9000
+
+keycloak:
+  admin:
+    password: "your-admin-password"
+  pgvector:
+    enabled: true
+    secret:
+      password: "your-db-password"
+  route:
+    enabled: true
 ```
 
 ### Shared Configuration with Global Values

--- a/keycloak/.helmignore
+++ b/keycloak/.helmignore
@@ -1,0 +1,31 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Documentation and test files
+README.md
+CHANGELOG.md
+LICENSE
+docs/
+examples/
+tests/
+

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,0 +1,461 @@
+# Keycloak Helm Chart
+
+Official Keycloak Helm chart for identity and access management.
+
+## Overview
+
+This Helm chart deploys Keycloak using the official Keycloak container images from `quay.io/keycloak/keycloak`. It supports:
+
+- Official Keycloak images (not Bitnami)
+- External database configuration (PostgreSQL, MySQL, MariaDB)
+- OpenShift Routes and Kubernetes Ingress
+- Production-optimized deployment
+- Flexible configuration via environment variables
+
+## Prerequisites
+
+- Kubernetes 1.19+ or OpenShift 4.x
+- Helm 3.0+
+- **No external database required** - This chart includes a pgvector PostgreSQL subchart
+- For external database: PostgreSQL, MySQL, or MariaDB
+
+## Installation
+
+### Standalone Installation (with built-in pgvector database)
+
+```bash
+# Create namespace
+kubectl create namespace keycloak
+
+# Install chart with built-in pgvector PostgreSQL
+helm install keycloak ./keycloak/helm \
+  --namespace keycloak \
+  --set admin.password=changeme \
+  --set pgvector.secret.password=changeme
+```
+
+### Standalone Installation (with external database)
+
+```bash
+# Install chart with external database
+helm install keycloak ./keycloak/helm \
+  --namespace keycloak \
+  --set admin.password=changeme \
+  --set pgvector.enabled=false \
+  --set pgvector.secret.host=postgresql.default.svc.cluster.local \
+  --set pgvector.secret.port=5432 \
+  --set pgvector.secret.user=keycloak \
+  --set pgvector.secret.password=changeme \
+  --set pgvector.secret.dbname=keycloak
+```
+
+### As Subchart (Used in other projects)
+
+This chart can be used as a dependency in other Helm charts:
+
+```yaml
+# Chart.yaml for your application
+dependencies:
+  - name: keycloak
+    version: "1.0.0"
+    repository: "file://../ai-architecture-charts/keycloak/helm"
+    # Or from Helm repository:
+    # repository: "https://rh-ai-quickstart.github.io/ai-architecture-charts"
+```
+
+```bash
+helm dependency update
+helm install my-app . --namespace my-namespace
+```
+
+## Configuration
+
+### Required Values
+
+```yaml
+admin:
+  password: "your-admin-password"  # Or use existingSecret
+
+# For built-in pgvector database (default):
+pgvector:
+  enabled: true
+  secret:
+    host: "pgvector"  # Auto-configured
+    password: "your-db-password"
+
+# For external database:
+pgvector:
+  enabled: false
+  secret:
+    host: "postgresql.default.svc.cluster.local"
+    port: "5432"
+    user: "keycloak"
+    password: "your-db-password"
+    dbname: "keycloak"
+```
+
+### Common Configuration Options
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicas` | Number of Keycloak replicas | `1` |
+| `image.registry` | Image registry | `quay.io` |
+| `image.repository` | Image repository | `keycloak/keycloak` |
+| `image.tag` | Image version | `26.0.7` |
+| `admin.username` | Admin username | `admin` |
+| `admin.password` | Admin password | `""` (required) |
+| `admin.existingSecret` | Existing secret for admin password | `""` |
+| `database.vendor` | Database type | `postgres` |
+| `pgvector.enabled` | Enable built-in PostgreSQL | `true` |
+| `pgvector.secret.host` | Database hostname | `pgvector` |
+| `pgvector.secret.port` | Database port | `5432` |
+| `pgvector.secret.user` | Database username | `keycloak` |
+| `pgvector.secret.password` | Database password | `""` (required) |
+| `pgvector.secret.dbname` | Database name | `keycloak` |
+| `config.proxy` | Proxy mode | `edge` |
+| `config.production` | Production mode | `true` |
+| `route.enabled` | Enable OpenShift Route | `true` |
+| `ingress.enabled` | Enable Kubernetes Ingress | `false` |
+
+For all available options, see `values.yaml`.
+
+## Examples
+
+### Using Existing Secrets (Recommended for Production)
+
+```yaml
+admin:
+  existingSecret: "keycloak-admin-secret"
+  existingSecretKey: "password"
+
+# Database credentials are always managed via pgvector.secret
+# For external database, set pgvector.secret.host and disable pgvector.enabled
+pgvector:
+  enabled: false  # Set to false for external database
+  secret:
+    host: "postgresql.example.com"  # External database hostname
+    port: "5432"
+    user: "keycloak"
+    password: "your-db-password"  # Set via --set flag
+    dbname: "keycloak"
+```
+
+```bash
+# Create admin secret
+kubectl create secret generic keycloak-admin-secret \
+  --from-literal=password='your-admin-password'
+
+# Install chart (database credentials via --set)
+helm install keycloak ./keycloak/helm \
+  --set pgvector.secret.host='postgresql.example.com' \
+  --set pgvector.secret.password='your-db-password'
+```
+
+### OpenShift with Custom Route
+
+```yaml
+route:
+  enabled: true
+  host: "keycloak.apps.example.com"
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+```
+
+### Kubernetes with Ingress
+
+```yaml
+route:
+  enabled: false
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  hosts:
+    - host: keycloak.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: keycloak-tls
+      hosts:
+        - keycloak.example.com
+```
+
+### High Availability Setup
+
+```yaml
+replicas: 3
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 1000m
+    memory: 1Gi
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+```
+
+### Custom Features
+
+```yaml
+config:
+  features: "token-exchange,admin-fine-grained-authz"
+  logLevel: "DEBUG"
+
+extraEnv:
+  - name: KC_SPI_THEME_DEFAULT
+    value: "custom"
+  - name: KC_DB_POOL_MAX_SIZE
+    value: "20"
+```
+
+## Database Setup
+
+### Built-in pgvector PostgreSQL (Default)
+
+By default, this chart deploys a dedicated **pgvector PostgreSQL instance** for Keycloak. No external database setup is required!
+
+**Automatic setup includes:**
+- ✅ PostgreSQL with pgvector extension
+- ✅ Dedicated database for Keycloak
+- ✅ Automatic user and permissions setup
+- ✅ Persistent volume for data
+
+**Configuration:**
+```yaml
+pgvector:
+  enabled: true  # Default
+  secret:
+    user: keycloak
+    password: changeme  # Change for production!
+    dbname: keycloak
+    port: "5432"
+```
+
+### External Database (Optional)
+
+If you prefer to use an external database, disable pgvector and configure all connection details via `pgvector.secret`:
+
+**Configuration:**
+```yaml
+pgvector:
+  enabled: false  # Disable built-in database
+  secret:
+    host: postgresql.example.com  # External database hostname
+    port: "5432"
+    user: keycloak
+    password: your-password  # Set via --set flag or values file
+    dbname: keycloak
+```
+
+**Note:** All database connection details (host, port, user, password, dbname) are configured via `pgvector.secret` for consistency.
+
+**PostgreSQL Setup Example:**
+
+```sql
+CREATE DATABASE keycloak;
+CREATE USER keycloak WITH PASSWORD 'your-password';
+GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
+
+-- Connect to keycloak database
+\c keycloak
+
+GRANT ALL ON SCHEMA public TO keycloak;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO keycloak;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO keycloak;
+```
+
+## Upgrading
+
+### Upgrade Keycloak Version
+
+```bash
+# Update values.yaml or use --set
+helm upgrade keycloak ./keycloak/helm \
+  --set image.tag=26.1.0 \
+  --reuse-values
+```
+
+### Upgrade Chart
+
+```bash
+helm upgrade keycloak ./keycloak/helm \
+  --namespace keycloak
+```
+
+## Uninstallation
+
+```bash
+helm uninstall keycloak --namespace keycloak
+```
+
+**Note:** This does not delete the database. Database cleanup must be done manually.
+
+## Troubleshooting
+
+### OpenID Configuration Shows localhost:8080 URLs
+
+**Problem:** The OpenID configuration endpoint returns URLs with `localhost:8080` instead of the external URL.
+
+**Cause:** Keycloak doesn't know its external hostname.
+
+**Solution:** Set the `KEYCLOAK_URL` in your `.env.production` file to the external URL:
+
+```bash
+# For OpenShift
+KEYCLOAK_URL=https://keycloak-spending-transaction-monitor.apps.example.com
+
+# For local development
+KEYCLOAK_URL=http://localhost:8080
+```
+
+The Makefile automatically extracts the hostname and sets `keycloak.config.hostname`.
+
+**Verify the fix:**
+```bash
+# Check if KC_HOSTNAME is set in the deployment
+oc get deployment spending-monitor-keycloak -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="KC_HOSTNAME")].value}'
+
+# Test the OpenID configuration
+curl https://your-keycloak-url/realms/spending-monitor/.well-known/openid-configuration | jq .issuer
+```
+
+### Pod Fails to Start
+
+Check logs:
+```bash
+kubectl logs -l app.kubernetes.io/name=keycloak --tail=100
+```
+
+Common issues:
+- Database connection failed (check host, credentials)
+- Missing admin password
+- Insufficient resources
+
+### Database Connection Errors
+
+Verify database connectivity:
+```bash
+kubectl run -it --rm debug --image=postgres:16 --restart=Never -- \
+  psql -h postgresql -U keycloak -d keycloak
+```
+
+### Access Admin Console
+
+Get the URL:
+```bash
+# OpenShift Route
+oc get route keycloak -o jsonpath='{.spec.host}'
+
+# Kubernetes Ingress
+kubectl get ingress keycloak -o jsonpath='{.spec.rules[0].host}'
+
+# Port forward
+kubectl port-forward svc/keycloak 8080:8080
+# Access: http://localhost:8080
+```
+
+## Health Checks
+
+Keycloak provides health endpoints:
+
+- **Liveness**: `GET /health/live`
+- **Readiness**: `GET /health/ready`
+- **Metrics**: `GET /metrics` (if enabled)
+
+## Security
+
+### Production Checklist
+
+- [ ] Use strong admin password
+- [ ] Use strong database password
+- [ ] Store passwords in Kubernetes Secrets
+- [ ] Enable TLS (via Route/Ingress)
+- [ ] Set `config.production: true`
+- [ ] Configure proper resource limits
+- [ ] Enable Pod Security Policies
+- [ ] Regular backups of database
+
+### RBAC
+
+The chart creates a ServiceAccount with minimal permissions. For additional permissions, create a RoleBinding:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keycloak-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: keycloak
+  namespace: keycloak
+```
+
+## Development
+
+### Local Testing
+
+```bash
+# Lint chart
+helm lint ./keycloak/helm
+
+# Render templates (with built-in database)
+helm template keycloak ./keycloak/helm \
+  --set admin.password=test \
+  --set pgvector.secret.password=test
+
+# Render templates (with external database)
+helm template keycloak ./keycloak/helm \
+  --set admin.password=test \
+  --set pgvector.enabled=false \
+  --set pgvector.secret.host=postgresql \
+  --set pgvector.secret.password=test
+
+# Dry run
+helm install keycloak ./keycloak/helm \
+  --dry-run --debug \
+  --set admin.password=test \
+  --set pgvector.secret.password=test
+```
+
+### Package Chart
+
+```bash
+helm package ./keycloak/helm
+```
+
+## References
+
+- [Keycloak Documentation](https://www.keycloak.org/documentation)
+- [Keycloak Container Guide](https://www.keycloak.org/server/containers)
+- [Keycloak Configuration](https://www.keycloak.org/server/all-config)
+- [Official Keycloak Images](https://quay.io/repository/keycloak/keycloak)
+
+## License
+
+This chart is provided as-is for use with the Spending Transaction Monitor application.
+
+## Support
+
+For issues and questions:
+- File an issue in the project repository
+- Check Keycloak community forums
+- Consult Keycloak documentation
+

--- a/keycloak/helm/Chart.lock
+++ b/keycloak/helm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: pgvector
+  repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
+  version: 0.5.1
+digest: sha256:a2d203583a1ffdd86324513435ea4ae64bdb3d943645712b9dc86b368124620d
+generated: "2025-11-20T11:16:01.132484-05:00"

--- a/keycloak/helm/Chart.yaml
+++ b/keycloak/helm/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: keycloak
+description: Official Keycloak Helm chart for identity and access management
+type: application
+version: 1.0.0
+appVersion: "26.0.7"
+dependencies:
+  - name: pgvector
+    version: 0.5.1
+    repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
+    condition: pgvector.enabled
+keywords:
+  - keycloak
+  - authentication
+  - authorization
+  - identity
+  - access-management
+  - oauth2
+  - openid-connect
+home: https://www.keycloak.org/
+sources:
+  - https://github.com/keycloak/keycloak
+icon: https://www.keycloak.org/resources/images/keycloak_icon_512px.svg
+maintainers:
+  - name: Development Team
+    email: dev@example.com
+

--- a/keycloak/helm/templates/_helpers.tpl
+++ b/keycloak/helm/templates/_helpers.tpl
@@ -1,0 +1,83 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keycloak.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "keycloak.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keycloak.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "keycloak.labels" -}}
+helm.sh/chart: {{ include "keycloak.chart" . }}
+{{ include "keycloak.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "keycloak.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keycloak.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "keycloak.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "keycloak.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get the admin password secret name
+*/}}
+{{- define "keycloak.adminSecretName" -}}
+{{- if .Values.admin.existingSecret }}
+{{- .Values.admin.existingSecret }}
+{{- else }}
+{{- include "keycloak.fullname" . }}-admin
+{{- end }}
+{{- end }}
+
+{{/*
+Get the database password secret name
+*/}}
+{{- define "keycloak.databaseSecretName" -}}
+{{- if .Values.database.existingSecret }}
+{{- .Values.database.existingSecret }}
+{{- else }}
+{{- include "keycloak.fullname" . }}-database
+{{- end }}
+{{- end }}
+

--- a/keycloak/helm/templates/deployment.yaml
+++ b/keycloak/helm/templates/deployment.yaml
@@ -1,0 +1,165 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "keycloak.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "keycloak.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "keycloak.serviceAccountName" . }}
+      containers:
+      - name: keycloak
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - start
+          # Note: Not using --optimized flag to allow auto-build on startup
+          # This adds ~30s to first startup but is more reliable
+        env:
+        # Database configuration
+        # All database credentials and connection details come from pgvector.secret
+        # For pgvector subchart: use default pgvector.secret.host = "pgvector"
+        # For external database: set pgvector.secret.host to external database hostname
+        - name: KC_DB
+          value: {{ .Values.database.vendor }}
+        - name: KC_DB_URL_HOST
+          value: {{ .Values.pgvector.secret.host | quote }}
+        - name: KC_DB_URL_PORT
+          value: {{ .Values.pgvector.secret.port | quote }}
+        - name: KC_DB_URL_DATABASE
+          value: {{ .Values.pgvector.secret.dbname }}
+        - name: KC_DB_USERNAME
+          value: {{ .Values.pgvector.secret.user }}
+        - name: KC_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: pgvector
+              key: password
+        
+        # Admin credentials
+        - name: KEYCLOAK_ADMIN
+          value: {{ .Values.admin.username }}
+        - name: KEYCLOAK_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "keycloak.adminSecretName" . }}
+              key: {{ .Values.admin.existingSecretKey }}
+        
+        # Proxy configuration
+        - name: KC_PROXY
+          value: {{ .Values.config.proxy }}
+        {{- if .Values.config.proxyHeaders }}
+        - name: KC_PROXY_HEADERS
+          value: {{ .Values.config.proxyHeaders }}
+        {{- end }}
+        
+        # Health and metrics
+        - name: KC_HEALTH_ENABLED
+          value: {{ .Values.config.healthEnabled | quote }}
+        - name: KC_METRICS_ENABLED
+          value: {{ .Values.config.metricsEnabled | quote }}
+        
+        # Hostname configuration
+        - name: KC_HOSTNAME_STRICT
+          value: {{ .Values.config.hostnameStrict | quote }}
+        - name: KC_HOSTNAME_STRICT_HTTPS
+          value: "false"
+        - name: KC_HTTP_ENABLED
+          value: "true"
+        {{- if .Values.config.hostname }}
+        - name: KC_HOSTNAME
+          value: {{ .Values.config.hostname }}
+        {{- end }}
+        
+        # Logging
+        - name: KC_LOG_LEVEL
+          value: {{ .Values.config.logLevel }}
+        
+        {{- if .Values.config.features }}
+        - name: KC_FEATURES
+          value: {{ .Values.config.features }}
+        {{- end }}
+        
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        
+        {{- with .Values.extraEnvFrom }}
+        envFrom:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        
+        {{- if .Values.livenessProbe }}
+        livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 10 }}
+        {{- end }}
+        
+        {{- if .Values.readinessProbe }}
+        readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 10 }}
+        {{- end }}
+        
+        {{- if .Values.resources }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
+        
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        
+        {{- with .Values.extraVolumeMounts }}
+        volumeMounts:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      
+      {{- with .Values.extraVolumes }}
+      volumes:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+

--- a/keycloak/helm/templates/ingress.yaml
+++ b/keycloak/helm/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "keycloak.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+

--- a/keycloak/helm/templates/route.yaml
+++ b/keycloak/helm/templates/route.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  {{- if .Values.route.path }}
+  path: {{ .Values.route.path }}
+  {{- end }}
+  port:
+    targetPort: http
+  tls:
+    termination: {{ .Values.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy }}
+  to:
+    kind: Service
+    name: {{ include "keycloak.fullname" . }}
+    weight: 100
+  wildcardPolicy: None
+{{- end }}
+

--- a/keycloak/helm/templates/secret.yaml
+++ b/keycloak/helm/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (not .Values.admin.existingSecret) .Values.admin.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "keycloak.fullname" . }}-admin
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.admin.existingSecretKey }}: {{ .Values.admin.password | b64enc | quote }}
+{{- end }}
+

--- a/keycloak/helm/templates/service.yaml
+++ b/keycloak/helm/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    {{- include "keycloak.selectorLabels" . | nindent 4 }}
+

--- a/keycloak/helm/templates/serviceaccount.yaml
+++ b/keycloak/helm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "keycloak.serviceAccountName" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+

--- a/keycloak/helm/values.yaml
+++ b/keycloak/helm/values.yaml
@@ -1,0 +1,218 @@
+# Default values for Keycloak Helm chart
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Global settings
+nameOverride: ""
+fullnameOverride: ""
+
+# Replica configuration
+replicas: 1
+
+# Image configuration - Official Keycloak image
+image:
+  registry: quay.io
+  repository: keycloak/keycloak
+  tag: "26.0.7"  # Official Keycloak version
+  pullPolicy: IfNotPresent
+
+# Admin user configuration
+admin:
+  username: admin
+  # Password should be provided via:
+  # 1. Existing secret (recommended for production)
+  # 2. Set via --set admin.password=xxx (for development)
+  password: ""
+  existingSecret: ""  # Name of existing secret containing admin password
+  existingSecretKey: "admin-password"  # Key in the secret
+
+# Database configuration
+database:
+  vendor: postgres  # Database type: postgres, mysql, mariadb, etc.
+
+# pgvector PostgreSQL subchart configuration
+# This deploys a dedicated PostgreSQL instance for Keycloak
+# All database connection details (host, port, user, password, dbname) are configured here
+pgvector:
+  enabled: true  # Enable pgvector subchart
+  secret:
+    host: pgvector  # Database host (for external DB, set to external hostname)
+    port: "5432"  # Database port
+    user: keycloak  # Database user for Keycloak
+    password: keycloak  # Database password (change for production!)
+    dbname: keycloak  # Database name for Keycloak
+# Keycloak configuration options
+config:
+  # Proxy mode for reverse proxies/load balancers
+  # Options: edge, reencrypt, passthrough, none
+  proxy: edge
+  proxyHeaders: xforwarded
+  
+  # Production mode (for future use - not currently used for --optimized flag)
+  # Note: Keycloak auto-builds configuration on startup for reliability
+  production: true
+  
+  # Health and metrics
+  healthEnabled: true
+  metricsEnabled: true
+  
+  # Hostname configuration
+  # hostname: The external hostname where Keycloak is accessible
+  # - This is used in OpenID configuration URLs (issuer, token endpoints, etc.)
+  # - Should be set to the OpenShift Route hostname or external URL
+  # - Automatically populated from KEYCLOAK_URL via Makefile
+  # - Format: hostname only (no protocol), e.g., "keycloak.apps.example.com"
+  hostnameStrict: false
+  hostname: ""  # Automatically set from KEYCLOAK_URL in Makefile
+  
+  # Logging
+  logLevel: INFO  # Options: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN
+  
+  # Features (comma-separated list)
+  # features: "token-exchange,admin-fine-grained-authz"
+  features: ""
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+# OpenShift Route configuration
+route:
+  enabled: true
+  host: ""  # Leave empty for auto-generated hostname
+  path: ""
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  annotations: {}
+
+# Kubernetes Ingress configuration (alternative to OpenShift Route)
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: keycloak.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: keycloak-tls
+  #    hosts:
+  #      - keycloak.example.com
+
+# Resource limits and requests
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+# Health probes
+# Note: Keycloak 26.x exposes health endpoints on management port 9000
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: 9000
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: 9000
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+# Security context for the pod
+podSecurityContext: {}
+  # fsGroup: 1000
+  # runAsUser: 1000
+  # runAsNonRoot: true
+
+# Security context for the container
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Service account
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# Pod annotations
+podAnnotations: {}
+
+# Pod labels
+podLabels: {}
+
+# Node selector
+nodeSelector: {}
+
+# Tolerations
+tolerations: []
+
+# Affinity
+affinity: {}
+
+# Extra environment variables
+extraEnv: []
+  # - name: KC_FEATURES
+  #   value: "token-exchange"
+  # - name: CUSTOM_VAR
+  #   value: "custom-value"
+
+# Extra environment variables from secrets/configmaps
+extraEnvFrom: []
+  # - secretRef:
+  #     name: keycloak-extra-secrets
+  # - configMapRef:
+  #     name: keycloak-extra-config
+
+# Extra volumes
+extraVolumes: []
+  # - name: custom-theme
+  #   configMap:
+  #     name: keycloak-theme
+
+# Extra volume mounts
+extraVolumeMounts: []
+  # - name: custom-theme
+  #   mountPath: /opt/keycloak/themes/custom
+  #   readOnly: true
+
+# Pod disruption budget
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# Horizontal Pod Autoscaler
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Priority class
+priorityClassName: ""
+


### PR DESCRIPTION
## Summary

This PR adds a standalone Keycloak Helm chart to the repository, following the established repository structure and patterns.

## Changes

- ✅ Restructured keycloak chart to follow repository pattern (`keycloak/helm/`)
- ✅ Updated pgvector dependency to version 0.5.1 (matching current pgvector version)
- ✅ Added condition for optional pgvector deployment
- ✅ Updated all documentation and installation paths
- ✅ Added keycloak to main README with usage examples
- ✅ Chart includes dedicated pgvector PostgreSQL instance for Keycloak

## Key Features

- **Standalone deployment** - No operator required
- **Built-in database** - Includes pgvector PostgreSQL subchart (optional, can use external DB)
- **OpenShift & Kubernetes** - Supports both Routes and Ingress
- **Production-ready** - Health checks, metrics, security contexts
- **Flexible configuration** - Extensive values.yaml options

## Usage

### Standalone Installation
```bash
helm install keycloak ./keycloak/helm \
  --namespace keycloak \
  --set admin.password=changeme \
  --set pgvector.secret.password=changeme
```

### As Dependency
```yaml
dependencies:
  - name: keycloak
    version: "1.0.0"
    repository: "file://../ai-architecture-charts/keycloak/helm"
```

## Notes

This is a standalone Keycloak chart that does not require any operators. It uses the official Keycloak container images and includes an optional pgvector PostgreSQL subchart for the database backend.