### PR TITLE
feat(keycloak)[RJ] : create a keycloak helm chart that can create users, relms, and groups on startup

### DIFF
--- a/keycloak/.helmignore
+++ b/keycloak/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -148,9 +148,136 @@ helm install keycloak ./helm -n keycloak -f production-values.yaml
 | `resources.limits.cpu` | CPU limit | `2000m` |
 | `resources.limits.memory` | Memory limit | `2Gi` |
 
+### Realm Import Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `realmImport.enabled` | Enable realm import at startup | `false` |
+| `realmImport.realms` | List of realm configurations to import | `[]` |
+| `realmImport.realms[].realm` | Realm name (required) | - |
+| `realmImport.realms[].displayName` | Display name for the realm | realm name |
+| `realmImport.realms[].clients` | List of OAuth/OIDC clients | `[]` |
+| `realmImport.realms[].roles.realm` | List of realm-level roles | `[]` |
+| `realmImport.realms[].users` | List of users with credentials and roles | `[]` |
+
 ### Advanced Configuration
 
 For a complete list of configuration options, see the `values.yaml` file.
+
+## Realm Import (Pre-configured Realms, Users, and Clients)
+
+Keycloak supports importing realm configurations at startup using the `--import-realm` flag. This chart leverages that feature to let you define realms, clients, roles, and users entirely in your `values.yaml` -- **no separate Job or post-deploy script needed**.
+
+### How It Works
+
+When `realmImport.enabled: true`:
+1. A ConfigMap is created for each realm containing the realm JSON configuration
+2. The ConfigMaps are mounted into the Keycloak container at `/opt/keycloak/data/import/`
+3. The `--import-realm` flag is automatically appended to the Keycloak startup args
+4. Keycloak reads and imports the realm(s) during startup
+
+### Example: Single Realm with Users and Clients
+
+```yaml
+realmImport:
+  enabled: true
+  realms:
+    - realm: "my-app"
+      enabled: true
+      displayName: "My Application"
+      ssoSessionIdleTimeout: 1800
+      accessTokenLifespan: 300
+      clients:
+        - clientId: "frontend-app"
+          enabled: true
+          publicClient: true
+          directAccessGrantsEnabled: true
+          redirectUris:
+            - "https://my-app.example.com/*"
+          webOrigins:
+            - "https://my-app.example.com"
+          protocol: "openid-connect"
+          standardFlowEnabled: true
+        - clientId: "backend-service"
+          enabled: true
+          publicClient: false
+          clientAuthenticatorType: "client-secret"
+          secret: "change-me-in-production"
+          serviceAccountsEnabled: true
+          protocol: "openid-connect"
+      roles:
+        realm:
+          - name: "admin"
+            description: "Administrator role"
+          - name: "user"
+            description: "Regular user role"
+      users:
+        - username: "admin-user"
+          enabled: true
+          emailVerified: true
+          firstName: "Admin"
+          lastName: "User"
+          email: "admin@example.com"
+          credentials:
+            - type: "password"
+              value: "change-me"
+              temporary: true
+          realmRoles:
+            - "admin"
+            - "user"
+        - username: "test-user"
+          enabled: true
+          firstName: "Test"
+          lastName: "User"
+          email: "test@example.com"
+          credentials:
+            - type: "password"
+              value: "testpassword"
+              temporary: false
+          realmRoles:
+            - "user"
+```
+
+### Example: Multiple Realms
+
+You can define multiple realms -- each gets its own ConfigMap:
+
+```yaml
+realmImport:
+  enabled: true
+  realms:
+    - realm: "internal"
+      enabled: true
+      displayName: "Internal Applications"
+      clients:
+        - clientId: "intranet"
+          enabled: true
+          publicClient: true
+          redirectUris: ["https://intranet.example.com/*"]
+      users:
+        - username: "employee1"
+          enabled: true
+          credentials:
+            - type: "password"
+              value: "welcome123"
+              temporary: true
+          realmRoles: ["user"]
+    - realm: "external"
+      enabled: true
+      displayName: "External Partners"
+      clients:
+        - clientId: "partner-portal"
+          enabled: true
+          publicClient: true
+          redirectUris: ["https://partners.example.com/*"]
+```
+
+### Important Notes
+
+- **Import behavior**: Keycloak will **skip** importing a realm if it already exists. It does **not** overwrite existing realms. To re-import, delete the realm first via the admin console.
+- **Temporary passwords**: Set `temporary: true` on user credentials to force a password change on first login (recommended for production).
+- **Client secrets**: For confidential clients, set `publicClient: false` and provide a `secret`. Rotate these in production.
+- **Startup time**: Importing large realm configurations may increase initial startup time slightly.
 
 ## Accessing Keycloak
 

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,48 +1,33 @@
 # Keycloak Helm Chart for OpenShift
 
-This Helm chart deploys Keycloak on OpenShift with support for authentication and identity management.
-
-## Overview
-
-Keycloak is an open-source identity and access management solution that provides:
-- Single Sign-On (SSO)
-- Identity Brokering and Social Login
-- User Federation
-- Client Adapters
-- Admin Console
-- Account Management Console
+Deploys Keycloak on OpenShift for authentication and identity management.
 
 ## Prerequisites
 
-- OpenShift cluster (4.x or later)
+- OpenShift cluster (4.x+)
 - Helm 3.x
-- kubectl/oc CLI
-- Optional: PostgreSQL database (recommended for production)
+- oc CLI
+- Optional: PostgreSQL database for production
 
 ## Installation
 
-### Development Mode (No External Database)
-
-Deploy Keycloak in development mode with built-in H2 database:
+### Development Mode
 
 ```bash
 helm install keycloak ./helm -n keycloak --create-namespace
 ```
 
-This uses `start-dev` mode which:
-- Uses built-in H2 database (data stored in-memory)
-- Configured with `--proxy-headers=xforwarded` for OpenShift route compatibility
-- Suitable for testing and development
-- **Not recommended for production**
+Uses `start-dev` with the built-in H2 database. Not recommended for production.
 
-**Note**: The proxy headers configuration is essential for OpenShift routes with TLS termination to prevent mixed content errors.
+### Production Mode
 
-### Production Mode (With External PostgreSQL Database)
+Create a `production-values.yaml`:
 
-For production deployments, use an external PostgreSQL database. Create a values file:
+You will need to have a postgres database to back this application.
 
-**production-values.yaml:**
 ```yaml
+replicaCount: 3
+
 args:
   - start
   - --optimized
@@ -52,93 +37,60 @@ args:
   - --proxy-headers=xforwarded
 
 secret:
+  adminUser: your-admin-username
+  adminPassword: YourSecurePassword123!
   dbEnabled: true
-  dbUrl: "jdbc:postgresql://postgres:5432/keycloak"
+  dbUrl: "jdbc:postgresql://postgres-host:5432/keycloak"
   dbUsername: keycloak
-  dbPassword: changeme
-```
+  dbPassword: your-secure-db-password
 
-Then install:
-```bash
-helm install keycloak ./helm -n keycloak --create-namespace -f production-values.yaml
-```
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: 8080
+  initialDelaySeconds: 120
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
 
-### Custom Installation
-
-Deploy with custom admin credentials:
-
-```bash
-helm install keycloak ./helm -n keycloak --create-namespace \
-  --set secret.adminUser=myadmin \
-  --set secret.adminPassword=mysecurepassword
-```
-
-### Using a Custom Values File (Production)
-
-Create a `production-values.yaml` file:
-
-```yaml
-replicaCount: 2
-
-image:
-  tag: "25.0.6"
-
-# Production mode args
-args:
-  - start
-  - --optimized
-  - --http-enabled=true
-  - --http-port=8080
-  - --hostname-strict=false
-  - --proxy-headers=xforwarded
-
-secret:
-  adminUser: admin
-  adminPassword: changeme
-  dbEnabled: true
-  dbUrl: "jdbc:postgresql://postgres:5432/keycloak"
-  dbUsername: keycloak
-  dbPassword: keycloak
-
-resources:
-  limits:
-    cpu: 2000m
-    memory: 2Gi
-  requests:
-    cpu: 1000m
-    memory: 1Gi
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
 
 persistence:
   enabled: true
   size: 5Gi
-
-route:
-  enabled: true
-  host: keycloak.apps.example.com
 ```
 
-Install with custom values:
+Install:
 
 ```bash
-helm install keycloak ./helm -n keycloak -f production-values.yaml
+helm install keycloak ./helm -n keycloak --create-namespace -f production-values.yaml
 ```
+
+**Note:** In production mode (`start --optimized`), health probes must use port 8080 instead of 9000.
 
 ## Configuration
 
-### Key Configuration Parameters
+### Key Parameters
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `replicaCount` | Number of Keycloak replicas | `1` |
-| `image.repository` | Keycloak image repository | `quay.io/keycloak/keycloak` |
-| `image.tag` | Keycloak image tag | `25.0.6` |
-| `args` | Keycloak startup arguments | `["start-dev", ...]` (dev mode) |
+| `replicaCount` | Number of replicas | `1` |
+| `image.repository` | Image repository | `quay.io/keycloak/keycloak` |
+| `image.tag` | Image tag | `25.0.6` |
+| `args` | Startup arguments | `["start-dev", "--proxy-headers=xforwarded"]` |
 | `secret.adminUser` | Admin username | `admin` |
 | `secret.adminPassword` | Admin password | `admin` |
-| `secret.dbEnabled` | Enable external database configuration | `false` |
-| `secret.dbUrl` | JDBC database URL (when dbEnabled=true) | `jdbc:postgresql://postgres:5432/keycloak` |
-| `secret.dbUsername` | Database username (when dbEnabled=true) | `keycloak` |
-| `secret.dbPassword` | Database password (when dbEnabled=true) | `keycloak` |
+| `secret.dbEnabled` | Enable external database | `false` |
+| `secret.dbUrl` | JDBC database URL | `jdbc:postgresql://postgres:5432/keycloak` |
+| `secret.dbUsername` | Database username | `keycloak` |
+| `secret.dbPassword` | Database password | `keycloak` |
 | `persistence.enabled` | Enable persistent storage | `false` |
 | `persistence.size` | PVC size | `1Gi` |
 | `route.enabled` | Create OpenShift route | `true` |
@@ -148,35 +100,28 @@ helm install keycloak ./helm -n keycloak -f production-values.yaml
 | `resources.limits.cpu` | CPU limit | `2000m` |
 | `resources.limits.memory` | Memory limit | `2Gi` |
 
-### Realm Import Configuration
+### Realm Import Parameters
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `realmImport.enabled` | Enable realm import at startup | `false` |
-| `realmImport.realms` | List of realm configurations to import | `[]` |
+| `realmImport.realms` | List of realm configurations | `[]` |
 | `realmImport.realms[].realm` | Realm name (required) | - |
-| `realmImport.realms[].displayName` | Display name for the realm | realm name |
-| `realmImport.realms[].clients` | List of OAuth/OIDC clients | `[]` |
-| `realmImport.realms[].roles.realm` | List of realm-level roles | `[]` |
-| `realmImport.realms[].users` | List of users with credentials and roles | `[]` |
+| `realmImport.realms[].displayName` | Display name | realm name |
+| `realmImport.realms[].clients` | OAuth/OIDC clients | `[]` |
+| `realmImport.realms[].roles.realm` | Realm-level roles | `[]` |
+| `realmImport.realms[].users` | Users with credentials and roles | `[]` |
 
-### Advanced Configuration
+## Realm Import
 
-For a complete list of configuration options, see the `values.yaml` file.
-
-## Realm Import (Pre-configured Realms, Users, and Clients)
-
-Keycloak supports importing realm configurations at startup using the `--import-realm` flag. This chart leverages that feature to let you define realms, clients, roles, and users entirely in your `values.yaml` -- **no separate Job or post-deploy script needed**.
-
-### How It Works
+Define realms, clients, roles, and users in `values.yaml` -- no separate Job needed. Keycloak imports them at startup via `--import-realm`.
 
 When `realmImport.enabled: true`:
-1. A ConfigMap is created for each realm containing the realm JSON configuration
-2. The ConfigMaps are mounted into the Keycloak container at `/opt/keycloak/data/import/`
-3. The `--import-realm` flag is automatically appended to the Keycloak startup args
-4. Keycloak reads and imports the realm(s) during startup
+1. A ConfigMap is created per realm with the JSON configuration
+2. Mounted into the container at `/opt/keycloak/data/import/`
+3. `--import-realm` is appended to the startup args
 
-### Example: Single Realm with Users and Clients
+### Example
 
 ```yaml
 realmImport:
@@ -198,13 +143,6 @@ realmImport:
             - "https://my-app.example.com"
           protocol: "openid-connect"
           standardFlowEnabled: true
-        - clientId: "backend-service"
-          enabled: true
-          publicClient: false
-          clientAuthenticatorType: "client-secret"
-          secret: "change-me-in-production"
-          serviceAccountsEnabled: true
-          protocol: "openid-connect"
       roles:
         realm:
           - name: "admin"
@@ -212,21 +150,9 @@ realmImport:
           - name: "user"
             description: "Regular user role"
       users:
-        - username: "admin-user"
+        - username: "testuser"
           enabled: true
           emailVerified: true
-          firstName: "Admin"
-          lastName: "User"
-          email: "admin@example.com"
-          credentials:
-            - type: "password"
-              value: "change-me"
-              temporary: true
-          realmRoles:
-            - "admin"
-            - "user"
-        - username: "test-user"
-          enabled: true
           firstName: "Test"
           lastName: "User"
           email: "test@example.com"
@@ -238,211 +164,43 @@ realmImport:
             - "user"
 ```
 
-### Example: Multiple Realms
-
-You can define multiple realms -- each gets its own ConfigMap:
-
-```yaml
-realmImport:
-  enabled: true
-  realms:
-    - realm: "internal"
-      enabled: true
-      displayName: "Internal Applications"
-      clients:
-        - clientId: "intranet"
-          enabled: true
-          publicClient: true
-          redirectUris: ["https://intranet.example.com/*"]
-      users:
-        - username: "employee1"
-          enabled: true
-          credentials:
-            - type: "password"
-              value: "welcome123"
-              temporary: true
-          realmRoles: ["user"]
-    - realm: "external"
-      enabled: true
-      displayName: "External Partners"
-      clients:
-        - clientId: "partner-portal"
-          enabled: true
-          publicClient: true
-          redirectUris: ["https://partners.example.com/*"]
-```
-
-### Important Notes
-
-- **Import behavior**: Keycloak will **skip** importing a realm if it already exists. It does **not** overwrite existing realms. To re-import, delete the realm first via the admin console.
-- **Temporary passwords**: Set `temporary: true` on user credentials to force a password change on first login (recommended for production).
-- **Client secrets**: For confidential clients, set `publicClient: false` and provide a `secret`. Rotate these in production.
-- **Startup time**: Importing large realm configurations may increase initial startup time slightly.
+**Notes:**
+- Keycloak skips importing a realm if it already exists. Delete the realm via the admin console to re-import.
+- Set `temporary: true` on credentials to force a password change on first login.
+- For confidential clients, set `publicClient: false` and provide a `secret`.
 
 ## Accessing Keycloak
 
-### Get the Route URL
+Get the route URL:
 
 ```bash
 oc get route keycloak -n keycloak -o jsonpath='{.spec.host}'
 ```
 
-### Access the Admin Console
+Navigate to `https://<hostname>/admin` and login with your admin credentials.
 
-1. Get the route hostname
-2. Navigate to `https://<hostname>/admin`
-3. Login with the admin credentials (default: admin/admin)
-
-### Get Admin Credentials
+Retrieve credentials from the secret:
 
 ```bash
 oc get secret keycloak-admin -n keycloak -o jsonpath='{.data.admin-user}' | base64 -d
 oc get secret keycloak-admin -n keycloak -o jsonpath='{.data.admin-password}' | base64 -d
 ```
 
-## Production Considerations
+## Production Notes
 
-### Production Requirements Overview
+| Aspect | Development | Production |
+|--------|-------------|------------|
+| Command | `start-dev` | `start --optimized` |
+| Database | H2 (in-memory) | PostgreSQL |
+| Health Probe Port | 9000 | 8080 |
+| Admin Credentials | admin/admin | Must be changed |
+| Replicas | 1 | 2-3+ recommended |
 
-To run Keycloak in production mode, several key changes are required:
-
-| Aspect | Development Mode | Production Mode |
-|--------|------------------|-----------------|
-| **Command** | `start-dev` | `start --optimized` |
-| **Database** | H2 (in-memory) | PostgreSQL (persistent) |
-| **Health Probe Port** | 9000 (management) | 8080 (main) |
-| **Data Persistence** | Lost on restart | Persisted to database |
-| **Admin Credentials** | admin/admin | **Must be changed** |
-| **Replicas** | 1 | 2-3+ recommended |
-| **Performance** | Not optimized | Pre-built & optimized |
-
-### 1. Database Setup (Required)
-
-For production deployments, use an external PostgreSQL database:
-
-1. Deploy PostgreSQL separately or use a managed database service
-2. Create a database for Keycloak:
-   ```sql
-   CREATE DATABASE keycloak;
-   CREATE USER keycloak WITH ENCRYPTED PASSWORD 'secure-password';
-   GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
-   ```
-
-### 2. Production Values Configuration
-
-Create a complete `production-values.yaml` file with all required changes:
-
-```yaml
-# Production replica count
-replicaCount: 3
-
-# Production startup arguments
-args:
-  - start                          # Use 'start' instead of 'start-dev'
-  - --optimized                    # Use pre-built optimized configuration
-  - --http-enabled=true
-  - --http-port=8080
-  - --hostname-strict=false
-  - --proxy-headers=xforwarded     # Required for OpenShift routes
-
-# Admin credentials (CHANGE THESE!)
-secret:
-  adminUser: your-admin-username
-  adminPassword: YourSecurePassword123!
-  dbEnabled: true
-  dbUrl: "jdbc:postgresql://postgres-host:5432/keycloak"
-  dbUsername: keycloak
-  dbPassword: your-secure-db-password
-
-# CRITICAL: Health probes must use port 8080 in production mode
-livenessProbe:
-  httpGet:
-    path: /health/live
-    port: 8080                     # Port 8080 for production (NOT 9000!)
-  initialDelaySeconds: 120
-  periodSeconds: 30
-  timeoutSeconds: 5
-  failureThreshold: 3
-
-readinessProbe:
-  httpGet:
-    path: /health/ready
-    port: 8080                     # Port 8080 for production (NOT 9000!)
-  initialDelaySeconds: 60
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 3
-
-# Production resource limits
-resources:
-  limits:
-    cpu: 2000m
-    memory: 2Gi
-  requests:
-    cpu: 1000m
-    memory: 1Gi
-
-# Optional: Enable persistence for custom themes/providers
-persistence:
-  enabled: true
-  size: 5Gi
-
-# High availability pod distribution
-affinity:
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - keycloak
-          topologyKey: kubernetes.io/hostname
-```
-
-### 3. Deploy Production Instance
-
-```bash
-helm install keycloak ./helm -n keycloak \
-  --create-namespace \
-  -f production-values.yaml
-```
-
-### Critical Production Notes
-
-⚠️ **Health Probe Port Configuration**
-- **Development mode**: Health endpoints are on port 9000 (management interface)
-- **Production mode**: Health endpoints are on port 8080 (main application port)
-- Failing to change this will cause pods to fail readiness checks!
-
-⚠️ **Security Requirements**
-- Always change default admin credentials (admin/admin)
-- Use strong, unique passwords for database access
-- Consider using Kubernetes Secrets or External Secrets Operator for credential management
-
-⚠️ **Database Requirement**
-- Production mode (`start --optimized`) requires an external database
-- H2 in-memory database is not available in production mode
-- Ensure database is created and accessible before deploying
-
-### 4. Additional Production Enhancements
-
-**High Availability**: The production configuration above includes pod anti-affinity rules to distribute Keycloak pods across different nodes for improved resilience.
-
-**Persistence**: Enabling persistent storage allows you to store custom themes, providers, and extensions that survive pod restarts.
-
-**Resource Limits**: Adjust CPU and memory limits based on your expected load and usage patterns.
-
-### Security Best Practices
-
-1. **Change Default Credentials**: Always change the default admin credentials
-2. **Use TLS**: Enable TLS termination at the route level
-3. **Database Passwords**: Use strong, randomly generated passwords
-4. **Network Policies**: Implement network policies to restrict access
-5. **Resource Limits**: Set appropriate resource limits to prevent resource exhaustion
-6. **Regular Updates**: Keep Keycloak updated to the latest stable version
+Key requirements:
+- An external PostgreSQL database is required for production mode
+- Health probes must target port 8080 (not 9000) in production
+- Always change the default admin credentials
+- Use strong passwords and consider External Secrets Operator for credential management
 
 ## Upgrading
 
@@ -456,7 +214,7 @@ helm upgrade keycloak ./helm -n keycloak -f custom-values.yaml
 helm uninstall keycloak -n keycloak
 ```
 
-To also delete the persistent volume claims:
+Delete persistent volume claims:
 
 ```bash
 oc delete pvc -l app.kubernetes.io/name=keycloak -n keycloak
@@ -464,52 +222,26 @@ oc delete pvc -l app.kubernetes.io/name=keycloak -n keycloak
 
 ## Troubleshooting
 
-### Pod Not Starting
-
 Check pod logs:
+
 ```bash
 oc logs -f deployment/keycloak -n keycloak
 ```
 
 Check pod events:
+
 ```bash
 oc describe pod -l app.kubernetes.io/name=keycloak -n keycloak
 ```
 
-### Database Connection Issues
-
-Verify database connectivity:
-```bash
-oc rsh deployment/keycloak -n keycloak
-# Inside the pod
-curl -v telnet://postgres-host:5432
-```
-
-Check database credentials:
-```bash
-oc get secret keycloak-db -n keycloak -o yaml
-```
-
-### Route Not Accessible
-
 Check route status:
+
 ```bash
 oc get route keycloak -n keycloak
-oc describe route keycloak -n keycloak
-```
-
-Verify service endpoints:
-```bash
-oc get endpoints keycloak -n keycloak
 ```
 
 ## Support
 
-For issues and questions:
-- Keycloak Documentation: https://www.keycloak.org/documentation
-- Keycloak GitHub: https://github.com/keycloak/keycloak
-- OpenShift Documentation: https://docs.openshift.com/
-
-## License
-
-This Helm chart follows the same license as the parent project.
+- [Keycloak Documentation](https://www.keycloak.org/documentation)
+- [Keycloak GitHub](https://github.com/keycloak/keycloak)
+- [OpenShift Documentation](https://docs.openshift.com/)

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -175,7 +175,21 @@ oc get secret keycloak-admin -n keycloak -o jsonpath='{.data.admin-password}' | 
 
 ## Production Considerations
 
-### Database
+### Production Requirements Overview
+
+To run Keycloak in production mode, several key changes are required:
+
+| Aspect | Development Mode | Production Mode |
+|--------|------------------|-----------------|
+| **Command** | `start-dev` | `start --optimized` |
+| **Database** | H2 (in-memory) | PostgreSQL (persistent) |
+| **Health Probe Port** | 9000 (management) | 8080 (main) |
+| **Data Persistence** | Lost on restart | Persisted to database |
+| **Admin Credentials** | admin/admin | **Must be changed** |
+| **Replicas** | 1 | 2-3+ recommended |
+| **Performance** | Not optimized | Pre-built & optimized |
+
+### 1. Database Setup (Required)
 
 For production deployments, use an external PostgreSQL database:
 
@@ -186,22 +200,67 @@ For production deployments, use an external PostgreSQL database:
    CREATE USER keycloak WITH ENCRYPTED PASSWORD 'secure-password';
    GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
    ```
-3. Enable database configuration in values:
-   ```yaml
-   secret:
-     dbEnabled: true
-     dbUrl: "jdbc:postgresql://postgres-host:5432/keycloak"
-     dbUsername: keycloak
-     dbPassword: secure-password
-   ```
 
-### High Availability
+### 2. Production Values Configuration
 
-For HA deployments:
+Create a complete `production-values.yaml` file with all required changes:
 
 ```yaml
+# Production replica count
 replicaCount: 3
 
+# Production startup arguments
+args:
+  - start                          # Use 'start' instead of 'start-dev'
+  - --optimized                    # Use pre-built optimized configuration
+  - --http-enabled=true
+  - --http-port=8080
+  - --hostname-strict=false
+  - --proxy-headers=xforwarded     # Required for OpenShift routes
+
+# Admin credentials (CHANGE THESE!)
+secret:
+  adminUser: your-admin-username
+  adminPassword: YourSecurePassword123!
+  dbEnabled: true
+  dbUrl: "jdbc:postgresql://postgres-host:5432/keycloak"
+  dbUsername: keycloak
+  dbPassword: your-secure-db-password
+
+# CRITICAL: Health probes must use port 8080 in production mode
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: 8080                     # Port 8080 for production (NOT 9000!)
+  initialDelaySeconds: 120
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: 8080                     # Port 8080 for production (NOT 9000!)
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# Production resource limits
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 1000m
+    memory: 1Gi
+
+# Optional: Enable persistence for custom themes/providers
+persistence:
+  enabled: true
+  size: 5Gi
+
+# High availability pod distribution
 affinity:
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
@@ -215,6 +274,39 @@ affinity:
                   - keycloak
           topologyKey: kubernetes.io/hostname
 ```
+
+### 3. Deploy Production Instance
+
+```bash
+helm install keycloak ./helm -n keycloak \
+  --create-namespace \
+  -f production-values.yaml
+```
+
+### Critical Production Notes
+
+⚠️ **Health Probe Port Configuration**
+- **Development mode**: Health endpoints are on port 9000 (management interface)
+- **Production mode**: Health endpoints are on port 8080 (main application port)
+- Failing to change this will cause pods to fail readiness checks!
+
+⚠️ **Security Requirements**
+- Always change default admin credentials (admin/admin)
+- Use strong, unique passwords for database access
+- Consider using Kubernetes Secrets or External Secrets Operator for credential management
+
+⚠️ **Database Requirement**
+- Production mode (`start --optimized`) requires an external database
+- H2 in-memory database is not available in production mode
+- Ensure database is created and accessible before deploying
+
+### 4. Additional Production Enhancements
+
+**High Availability**: The production configuration above includes pod anti-affinity rules to distribute Keycloak pods across different nodes for improved resilience.
+
+**Persistence**: Enabling persistent storage allows you to store custom themes, providers, and extensions that survive pod restarts.
+
+**Resource Limits**: Adjust CPU and memory limits based on your expected load and usage patterns.
 
 ### Security Best Practices
 

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -100,74 +100,19 @@ helm install keycloak ./helm -n keycloak --create-namespace -f production-values
 | `resources.limits.cpu` | CPU limit | `2000m` |
 | `resources.limits.memory` | Memory limit | `2Gi` |
 
-### Realm Import Parameters
+### Realm Import
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `realmImport.enabled` | Enable realm import at startup | `false` |
-| `realmImport.realms` | List of realm configurations | `[]` |
-| `realmImport.realms[].realm` | Realm name (required) | - |
-| `realmImport.realms[].displayName` | Display name | realm name |
-| `realmImport.realms[].clients` | OAuth/OIDC clients | `[]` |
-| `realmImport.realms[].roles.realm` | Realm-level roles | `[]` |
-| `realmImport.realms[].users` | Users with credentials and roles | `[]` |
+| `realmImport.enabled` | Enable realm import at startup | `true` |
 
-## Realm Import
+When enabled, the chart loads `realm.json` from the chart directory into a ConfigMap, mounts it at `/opt/keycloak/data/import/`, and appends `--import-realm` to the startup args. Keycloak imports the realm on first startup.
 
-Define realms, clients, roles, and users in `values.yaml` -- no separate Job needed. Keycloak imports them at startup via `--import-realm`.
-
-When `realmImport.enabled: true`:
-1. A ConfigMap is created per realm with the JSON configuration
-2. Mounted into the container at `/opt/keycloak/data/import/`
-3. `--import-realm` is appended to the startup args
-
-### Example
-
-```yaml
-realmImport:
-  enabled: true
-  realms:
-    - realm: "my-app"
-      enabled: true
-      displayName: "My Application"
-      ssoSessionIdleTimeout: 1800
-      accessTokenLifespan: 300
-      clients:
-        - clientId: "frontend-app"
-          enabled: true
-          publicClient: true
-          directAccessGrantsEnabled: true
-          redirectUris:
-            - "https://my-app.example.com/*"
-          webOrigins:
-            - "https://my-app.example.com"
-          protocol: "openid-connect"
-          standardFlowEnabled: true
-      roles:
-        realm:
-          - name: "admin"
-            description: "Administrator role"
-          - name: "user"
-            description: "Regular user role"
-      users:
-        - username: "testuser"
-          enabled: true
-          emailVerified: true
-          firstName: "Test"
-          lastName: "User"
-          email: "test@example.com"
-          credentials:
-            - type: "password"
-              value: "testpassword"
-              temporary: false
-          realmRoles:
-            - "user"
-```
+Edit `helm/realm.json` to define your realm, clients, roles, and users. See the [Keycloak Server Administration Guide](https://www.keycloak.org/docs/latest/server_admin/#_export_import) for the full JSON schema.
 
 **Notes:**
 - Keycloak skips importing a realm if it already exists. Delete the realm via the admin console to re-import.
-- Set `temporary: true` on credentials to force a password change on first login.
-- For confidential clients, set `publicClient: false` and provide a `secret`.
+- Set `temporary: true` on user credentials to force a password change on first login.
 
 ## Accessing Keycloak
 

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,17 +1,27 @@
-# Keycloak Helm Chart for OpenShift
+# Keycloak Helm Chart
 
-Deploys Keycloak on OpenShift for authentication and identity management.
+This Helm chart deploys Keycloak on OpenShift for authentication and identity management, providing SSO (Single Sign-On) capabilities for applications.
+
+## Overview
+
+The keycloak chart creates:
+- A Keycloak deployment for identity and access management
+- OpenShift Route for external access
+- Secrets for admin credentials and database configuration
+- Optional persistent volume claims for data storage
+- Optional realm import via ConfigMap
+- Health probes for container lifecycle management
 
 ## Prerequisites
 
 - OpenShift cluster (4.x+)
 - Helm 3.x
 - oc CLI
-- Optional: PostgreSQL database for production
+- Optional: PostgreSQL database for production deployments
 
 ## Installation
 
-### Development Mode
+### Basic Installation (Development Mode)
 
 ```bash
 helm install keycloak ./helm -n keycloak --create-namespace
@@ -19,11 +29,120 @@ helm install keycloak ./helm -n keycloak --create-namespace
 
 Uses `start-dev` with the built-in H2 database. Not recommended for production.
 
-### Production Mode
+### Installation with Custom Admin Credentials
 
-Create a `production-values.yaml`:
+```bash
+helm install keycloak ./helm \
+  --namespace keycloak \
+  --create-namespace \
+  --set secret.adminUser=myadmin \
+  --set secret.adminPassword=MySecurePassword123!
+```
 
-You will need to have a postgres database to back this application.
+### Installation with External PostgreSQL
+
+```bash
+helm install keycloak ./helm \
+  --namespace keycloak \
+  --create-namespace \
+  --set secret.dbEnabled=true \
+  --set secret.dbUrl="jdbc:postgresql://postgres-host:5432/keycloak" \
+  --set secret.dbUsername=keycloak \
+  --set secret.dbPassword=your-db-password
+```
+
+### Installation with Custom Namespace
+
+```bash
+helm install keycloak ./helm \
+  --namespace identity \
+  --create-namespace
+```
+
+## Configuration
+
+### Key Configuration Options
+
+#### Keycloak Core Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of replicas | `1` |
+| `image.repository` | Image repository | `quay.io/keycloak/keycloak` |
+| `image.tag` | Image tag | `25.0.6` |
+| `args` | Startup arguments | `["start-dev", "--proxy-headers=xforwarded"]` |
+
+#### Admin Credentials Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `secret.adminUser` | Admin username | `admin` |
+| `secret.adminPassword` | Admin password | `admin` |
+
+#### Database Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `secret.dbEnabled` | Enable external database | `false` |
+| `secret.dbUrl` | JDBC database URL | `jdbc:postgresql://postgres:5432/keycloak` |
+| `secret.dbUsername` | Database username | `keycloak` |
+| `secret.dbPassword` | Database password | `keycloak` |
+
+#### Route Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `route.enabled` | Create OpenShift route | `true` |
+| `route.host` | Custom hostname for route | `""` (auto-generated) |
+
+#### Persistence Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `persistence.enabled` | Enable persistent storage | `false` |
+| `persistence.size` | PVC size | `1Gi` |
+
+#### Resource Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `resources.requests.cpu` | CPU request | `500m` |
+| `resources.requests.memory` | Memory request | `1Gi` |
+| `resources.limits.cpu` | CPU limit | `2000m` |
+| `resources.limits.memory` | Memory limit | `2Gi` |
+
+#### Realm Import Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `realmImport.enabled` | Enable realm import at startup | `true` |
+
+When enabled, the chart loads `realm.json` from the chart directory into a ConfigMap, mounts it at `/opt/keycloak/data/import/`, and appends `--import-realm` to the startup args.
+
+### Example values.yaml
+
+#### Example 1: Development Mode (default)
+
+```yaml
+replicaCount: 1
+
+args:
+  - start-dev
+  - --proxy-headers=xforwarded
+
+secret:
+  adminUser: admin
+  adminPassword: admin
+  dbEnabled: false
+
+route:
+  enabled: true
+
+realmImport:
+  enabled: true
+```
+
+#### Example 2: Production Mode with PostgreSQL
 
 ```yaml
 replicaCount: 3
@@ -37,7 +156,7 @@ args:
   - --proxy-headers=xforwarded
 
 secret:
-  adminUser: your-admin-username
+  adminUser: keycloak-admin
   adminPassword: YourSecurePassword123!
   dbEnabled: true
   dbUrl: "jdbc:postgresql://postgres-host:5432/keycloak"
@@ -65,56 +184,56 @@ readinessProbe:
 persistence:
   enabled: true
   size: 5Gi
+
+resources:
+  requests:
+    cpu: "1000m"
+    memory: "2Gi"
+  limits:
+    cpu: "4000m"
+    memory: "4Gi"
 ```
 
-Install:
+#### Example 3: Custom Realm Import
 
-```bash
-helm install keycloak ./helm -n keycloak --create-namespace -f production-values.yaml
+```yaml
+replicaCount: 1
+
+secret:
+  adminUser: admin
+  adminPassword: admin
+
+realmImport:
+  enabled: true
+
+route:
+  enabled: true
+  host: keycloak.apps.example.com
 ```
-
-**Note:** In production mode (`start --optimized`), health probes must use port 8080 instead of 9000.
-
-## Configuration
-
-### Key Parameters
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `replicaCount` | Number of replicas | `1` |
-| `image.repository` | Image repository | `quay.io/keycloak/keycloak` |
-| `image.tag` | Image tag | `25.0.6` |
-| `args` | Startup arguments | `["start-dev", "--proxy-headers=xforwarded"]` |
-| `secret.adminUser` | Admin username | `admin` |
-| `secret.adminPassword` | Admin password | `admin` |
-| `secret.dbEnabled` | Enable external database | `false` |
-| `secret.dbUrl` | JDBC database URL | `jdbc:postgresql://postgres:5432/keycloak` |
-| `secret.dbUsername` | Database username | `keycloak` |
-| `secret.dbPassword` | Database password | `keycloak` |
-| `persistence.enabled` | Enable persistent storage | `false` |
-| `persistence.size` | PVC size | `1Gi` |
-| `route.enabled` | Create OpenShift route | `true` |
-| `route.host` | Custom hostname for route | `""` (auto-generated) |
-| `resources.requests.cpu` | CPU request | `500m` |
-| `resources.requests.memory` | Memory request | `1Gi` |
-| `resources.limits.cpu` | CPU limit | `2000m` |
-| `resources.limits.memory` | Memory limit | `2Gi` |
-
-### Realm Import
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `realmImport.enabled` | Enable realm import at startup | `true` |
-
-When enabled, the chart loads `realm.json` from the chart directory into a ConfigMap, mounts it at `/opt/keycloak/data/import/`, and appends `--import-realm` to the startup args. Keycloak imports the realm on first startup.
 
 Edit `helm/realm.json` to define your realm, clients, roles, and users. See the [Keycloak Server Administration Guide](https://www.keycloak.org/docs/latest/server_admin/#_export_import) for the full JSON schema.
 
-**Notes:**
-- Keycloak skips importing a realm if it already exists. Delete the realm via the admin console to re-import.
-- Set `temporary: true` on user credentials to force a password change on first login.
+## Usage
 
-## Accessing Keycloak
+After installation, the chart will create:
+
+1. **Keycloak Deployment**: A complete identity and access management server
+2. **OpenShift Route**: External HTTPS access to the Keycloak console
+3. **Secrets**: Admin credentials and optional database configuration
+4. **ConfigMap** (optional): Realm import configuration
+5. **PVC** (optional): Persistent storage for Keycloak data
+
+### Development vs Production Mode
+
+| Aspect | Development | Production |
+|--------|-------------|------------|
+| Command | `start-dev` | `start --optimized` |
+| Database | H2 (in-memory) | PostgreSQL |
+| Health Probe Port | 9000 | 8080 |
+| Admin Credentials | admin/admin | Must be changed |
+| Replicas | 1 | 2-3+ recommended |
+
+### Accessing Keycloak
 
 Get the route URL:
 
@@ -131,23 +250,74 @@ oc get secret keycloak-admin -n keycloak -o jsonpath='{.data.admin-user}' | base
 oc get secret keycloak-admin -n keycloak -o jsonpath='{.data.admin-password}' | base64 -d
 ```
 
-## Production Notes
+### Realm Import
 
-| Aspect | Development | Production |
-|--------|-------------|------------|
-| Command | `start-dev` | `start --optimized` |
-| Database | H2 (in-memory) | PostgreSQL |
-| Health Probe Port | 9000 | 8080 |
-| Admin Credentials | admin/admin | Must be changed |
-| Replicas | 1 | 2-3+ recommended |
+When `realmImport.enabled: true`:
+- Keycloak imports the realm on first startup
+- Keycloak skips importing a realm if it already exists
+- Delete the realm via the admin console to re-import
+- Set `temporary: true` on user credentials to force a password change on first login
 
-Key requirements:
-- An external PostgreSQL database is required for production mode
-- Health probes must target port 8080 (not 9000) in production
-- Always change the default admin credentials
-- Use strong passwords and consider External Secrets Operator for credential management
+## Monitoring and Troubleshooting
+
+### Checking Pod Status
+
+```bash
+oc get pods -l app.kubernetes.io/name=keycloak -n keycloak
+```
+
+### Viewing Logs
+
+```bash
+oc logs -f deployment/keycloak -n keycloak
+```
+
+### Common Issues
+
+1. **Pod won't start (CrashLoopBackOff)**:
+   - Check if health probe ports match the startup mode (9000 for dev, 8080 for production)
+   - Verify database connectivity if using external PostgreSQL
+   - Check resource limits are sufficient
+
+2. **Database connection issues**:
+   - Verify PostgreSQL is running and accessible
+   - Check JDBC URL format and credentials
+   - Ensure network policies allow connectivity
+
+3. **Route not accessible**:
+   - Check route status: `oc get route keycloak -n keycloak`
+   - Verify TLS configuration
+   - Check router pods in openshift-ingress namespace
+
+4. **Realm import not working**:
+   - Verify `realm.json` exists in the helm directory
+   - Check if realm already exists (import is skipped)
+   - Review pod logs for import errors
+
+5. **Health probe failures**:
+   - In production mode (`start --optimized`), health probes must use port 8080
+   - In development mode (`start-dev`), health probes use port 9000
+   - Increase `initialDelaySeconds` if Keycloak needs more startup time
+
+### Checking Configuration
+
+```bash
+# Check secrets
+oc get secrets -l app.kubernetes.io/name=keycloak -n keycloak
+
+# Check configmaps
+oc get configmaps -l app.kubernetes.io/name=keycloak -n keycloak
+
+# Check PVCs
+oc get pvc -l app.kubernetes.io/name=keycloak -n keycloak
+
+# Check route
+oc get route keycloak -n keycloak
+```
 
 ## Upgrading
+
+To upgrade the chart:
 
 ```bash
 helm upgrade keycloak ./helm -n keycloak -f custom-values.yaml
@@ -159,31 +329,28 @@ helm upgrade keycloak ./helm -n keycloak -f custom-values.yaml
 helm uninstall keycloak -n keycloak
 ```
 
-Delete persistent volume claims:
+**Note**: This will not delete PVCs by default. To also remove persistent data:
 
 ```bash
 oc delete pvc -l app.kubernetes.io/name=keycloak -n keycloak
 ```
 
-## Troubleshooting
+## Dependencies
 
-Check pod logs:
+- **OpenShift cluster**: Required for Route resources and container platform
+- **PostgreSQL** (production): External database for production deployments
+- **Sufficient cluster resources**: CPU, memory, and storage
+- **Container registry access**: For pulling Keycloak images from quay.io
+- **Network connectivity**: Between Keycloak and database (if external)
 
-```bash
-oc logs -f deployment/keycloak -n keycloak
-```
+## Integration
 
-Check pod events:
+This chart works well with other components in the AI architecture:
 
-```bash
-oc describe pod -l app.kubernetes.io/name=keycloak -n keycloak
-```
-
-Check route status:
-
-```bash
-oc get route keycloak -n keycloak
-```
+- **llama-stack**: Secure LLM inference with Keycloak authentication
+- **configure-pipeline**: Protect data science pipelines with SSO
+- **pgvector**: Share PostgreSQL infrastructure for both Keycloak and vector storage
+- **minio**: Secure object storage access with Keycloak policies
 
 ## Support
 

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,0 +1,296 @@
+# Keycloak Helm Chart for OpenShift
+
+This Helm chart deploys Keycloak on OpenShift with support for authentication and identity management.
+
+## Overview
+
+Keycloak is an open-source identity and access management solution that provides:
+- Single Sign-On (SSO)
+- Identity Brokering and Social Login
+- User Federation
+- Client Adapters
+- Admin Console
+- Account Management Console
+
+## Prerequisites
+
+- OpenShift cluster (4.x or later)
+- Helm 3.x
+- kubectl/oc CLI
+- Optional: PostgreSQL database (recommended for production)
+
+## Installation
+
+### Development Mode (No External Database)
+
+Deploy Keycloak in development mode with built-in H2 database:
+
+```bash
+helm install keycloak ./helm -n keycloak --create-namespace
+```
+
+This uses `start-dev` mode which:
+- Uses built-in H2 database (data stored in-memory)
+- Configured with `--proxy-headers=xforwarded` for OpenShift route compatibility
+- Suitable for testing and development
+- **Not recommended for production**
+
+**Note**: The proxy headers configuration is essential for OpenShift routes with TLS termination to prevent mixed content errors.
+
+### Production Mode (With External PostgreSQL Database)
+
+For production deployments, use an external PostgreSQL database. Create a values file:
+
+**production-values.yaml:**
+```yaml
+args:
+  - start
+  - --optimized
+  - --http-enabled=true
+  - --http-port=8080
+  - --hostname-strict=false
+  - --proxy-headers=xforwarded
+
+secret:
+  dbEnabled: true
+  dbUrl: "jdbc:postgresql://postgres:5432/keycloak"
+  dbUsername: keycloak
+  dbPassword: changeme
+```
+
+Then install:
+```bash
+helm install keycloak ./helm -n keycloak --create-namespace -f production-values.yaml
+```
+
+### Custom Installation
+
+Deploy with custom admin credentials:
+
+```bash
+helm install keycloak ./helm -n keycloak --create-namespace \
+  --set secret.adminUser=myadmin \
+  --set secret.adminPassword=mysecurepassword
+```
+
+### Using a Custom Values File (Production)
+
+Create a `production-values.yaml` file:
+
+```yaml
+replicaCount: 2
+
+image:
+  tag: "25.0.6"
+
+# Production mode args
+args:
+  - start
+  - --optimized
+  - --http-enabled=true
+  - --http-port=8080
+  - --hostname-strict=false
+  - --proxy-headers=xforwarded
+
+secret:
+  adminUser: admin
+  adminPassword: changeme
+  dbEnabled: true
+  dbUrl: "jdbc:postgresql://postgres:5432/keycloak"
+  dbUsername: keycloak
+  dbPassword: keycloak
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 1000m
+    memory: 1Gi
+
+persistence:
+  enabled: true
+  size: 5Gi
+
+route:
+  enabled: true
+  host: keycloak.apps.example.com
+```
+
+Install with custom values:
+
+```bash
+helm install keycloak ./helm -n keycloak -f production-values.yaml
+```
+
+## Configuration
+
+### Key Configuration Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of Keycloak replicas | `1` |
+| `image.repository` | Keycloak image repository | `quay.io/keycloak/keycloak` |
+| `image.tag` | Keycloak image tag | `25.0.6` |
+| `args` | Keycloak startup arguments | `["start-dev", ...]` (dev mode) |
+| `secret.adminUser` | Admin username | `admin` |
+| `secret.adminPassword` | Admin password | `admin` |
+| `secret.dbEnabled` | Enable external database configuration | `false` |
+| `secret.dbUrl` | JDBC database URL (when dbEnabled=true) | `jdbc:postgresql://postgres:5432/keycloak` |
+| `secret.dbUsername` | Database username (when dbEnabled=true) | `keycloak` |
+| `secret.dbPassword` | Database password (when dbEnabled=true) | `keycloak` |
+| `persistence.enabled` | Enable persistent storage | `false` |
+| `persistence.size` | PVC size | `1Gi` |
+| `route.enabled` | Create OpenShift route | `true` |
+| `route.host` | Custom hostname for route | `""` (auto-generated) |
+| `resources.requests.cpu` | CPU request | `500m` |
+| `resources.requests.memory` | Memory request | `1Gi` |
+| `resources.limits.cpu` | CPU limit | `2000m` |
+| `resources.limits.memory` | Memory limit | `2Gi` |
+
+### Advanced Configuration
+
+For a complete list of configuration options, see the `values.yaml` file.
+
+## Accessing Keycloak
+
+### Get the Route URL
+
+```bash
+oc get route keycloak -n keycloak -o jsonpath='{.spec.host}'
+```
+
+### Access the Admin Console
+
+1. Get the route hostname
+2. Navigate to `https://<hostname>/admin`
+3. Login with the admin credentials (default: admin/admin)
+
+### Get Admin Credentials
+
+```bash
+oc get secret keycloak-admin -n keycloak -o jsonpath='{.data.admin-user}' | base64 -d
+oc get secret keycloak-admin -n keycloak -o jsonpath='{.data.admin-password}' | base64 -d
+```
+
+## Production Considerations
+
+### Database
+
+For production deployments, use an external PostgreSQL database:
+
+1. Deploy PostgreSQL separately or use a managed database service
+2. Create a database for Keycloak:
+   ```sql
+   CREATE DATABASE keycloak;
+   CREATE USER keycloak WITH ENCRYPTED PASSWORD 'secure-password';
+   GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
+   ```
+3. Enable database configuration in values:
+   ```yaml
+   secret:
+     dbEnabled: true
+     dbUrl: "jdbc:postgresql://postgres-host:5432/keycloak"
+     dbUsername: keycloak
+     dbPassword: secure-password
+   ```
+
+### High Availability
+
+For HA deployments:
+
+```yaml
+replicaCount: 3
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - keycloak
+          topologyKey: kubernetes.io/hostname
+```
+
+### Security Best Practices
+
+1. **Change Default Credentials**: Always change the default admin credentials
+2. **Use TLS**: Enable TLS termination at the route level
+3. **Database Passwords**: Use strong, randomly generated passwords
+4. **Network Policies**: Implement network policies to restrict access
+5. **Resource Limits**: Set appropriate resource limits to prevent resource exhaustion
+6. **Regular Updates**: Keep Keycloak updated to the latest stable version
+
+## Upgrading
+
+```bash
+helm upgrade keycloak ./helm -n keycloak -f custom-values.yaml
+```
+
+## Uninstalling
+
+```bash
+helm uninstall keycloak -n keycloak
+```
+
+To also delete the persistent volume claims:
+
+```bash
+oc delete pvc -l app.kubernetes.io/name=keycloak -n keycloak
+```
+
+## Troubleshooting
+
+### Pod Not Starting
+
+Check pod logs:
+```bash
+oc logs -f deployment/keycloak -n keycloak
+```
+
+Check pod events:
+```bash
+oc describe pod -l app.kubernetes.io/name=keycloak -n keycloak
+```
+
+### Database Connection Issues
+
+Verify database connectivity:
+```bash
+oc rsh deployment/keycloak -n keycloak
+# Inside the pod
+curl -v telnet://postgres-host:5432
+```
+
+Check database credentials:
+```bash
+oc get secret keycloak-db -n keycloak -o yaml
+```
+
+### Route Not Accessible
+
+Check route status:
+```bash
+oc get route keycloak -n keycloak
+oc describe route keycloak -n keycloak
+```
+
+Verify service endpoints:
+```bash
+oc get endpoints keycloak -n keycloak
+```
+
+## Support
+
+For issues and questions:
+- Keycloak Documentation: https://www.keycloak.org/documentation
+- Keycloak GitHub: https://github.com/keycloak/keycloak
+- OpenShift Documentation: https://docs.openshift.com/
+
+## License
+
+This Helm chart follows the same license as the parent project.

--- a/keycloak/helm/Chart.yaml
+++ b/keycloak/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: keycloak
+description: A Helm chart for Keycloak on OpenShift
+type: application
+version: 0.1.0
+appVersion: "25.0.6"

--- a/keycloak/helm/realm.json
+++ b/keycloak/helm/realm.json
@@ -1,0 +1,37 @@
+{
+    "realm": "myrealm",
+    "enabled": true,
+    "roles": {
+      "realm": [
+        { "name": "admin" },
+        { "name": "user" },
+        { "name": "service-account" }
+      ]
+    },
+    "users": [
+      {
+        "username": "ryan-johnson",
+        "enabled": true,
+        "credentials": [
+          { "type": "password", "value": "password123", "temporary": true }
+        ],
+        "realmRoles": ["admin"]
+      },
+      {
+        "username": "service-account",
+        "enabled": true,
+        "credentials": [
+          { "type": "password", "value": "password123", "temporary": true }
+        ],
+        "realmRoles": ["service-account"]
+      },
+      {
+        "username": "user",
+        "enabled": true,
+        "credentials": [
+          { "type": "password", "value": "password123", "temporary": true }
+        ],
+        "realmRoles": ["user"]
+      }
+    ]
+  }

--- a/keycloak/helm/templates/_helpers.tpl
+++ b/keycloak/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keycloak.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "keycloak.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keycloak.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "keycloak.labels" -}}
+helm.sh/chart: {{ include "keycloak.chart" . }}
+{{ include "keycloak.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "keycloak.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keycloak.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "keycloak.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "keycloak.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/keycloak/helm/templates/configmap-realm-import.yaml
+++ b/keycloak/helm/templates/configmap-realm-import.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.realmImport.enabled }}
+{{- range $index, $realm := .Values.realmImport.realms }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "keycloak.fullname" $ }}-realm-{{ $realm.realm }}
+  labels:
+    {{- include "keycloak.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: realm-import
+data:
+  {{ $realm.realm }}-realm.json: |
+    {{- $realmConfig := dict
+      "realm" $realm.realm
+      "enabled" (default true $realm.enabled)
+      "displayName" (default $realm.realm $realm.displayName)
+    }}
+    {{- if $realm.ssoSessionIdleTimeout }}
+      {{- $_ := set $realmConfig "ssoSessionIdleTimeout" $realm.ssoSessionIdleTimeout }}
+    {{- end }}
+    {{- if $realm.ssoSessionMaxLifespan }}
+      {{- $_ := set $realmConfig "ssoSessionMaxLifespan" $realm.ssoSessionMaxLifespan }}
+    {{- end }}
+    {{- if $realm.accessTokenLifespan }}
+      {{- $_ := set $realmConfig "accessTokenLifespan" $realm.accessTokenLifespan }}
+    {{- end }}
+    {{- if $realm.clients }}
+      {{- $_ := set $realmConfig "clients" $realm.clients }}
+    {{- end }}
+    {{- if $realm.roles }}
+      {{- $_ := set $realmConfig "roles" $realm.roles }}
+    {{- end }}
+    {{- if $realm.users }}
+      {{- $_ := set $realmConfig "users" $realm.users }}
+    {{- end }}
+    {{ $realmConfig | toJson | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/keycloak/helm/templates/configmap-realm-import.yaml
+++ b/keycloak/helm/templates/configmap-realm-import.yaml
@@ -1,38 +1,11 @@
 {{- if .Values.realmImport.enabled }}
-{{- range $index, $realm := .Values.realmImport.realms }}
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "keycloak.fullname" $ }}-realm-{{ $realm.realm }}
+  name: {{ include "keycloak.fullname" . }}-realm-import
   labels:
-    {{- include "keycloak.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: realm-import
+    {{- include "keycloak.labels" . | nindent 4 }}
 data:
-  {{ $realm.realm }}-realm.json: |
-    {{- $realmConfig := dict
-      "realm" $realm.realm
-      "enabled" (default true $realm.enabled)
-      "displayName" (default $realm.realm $realm.displayName)
-    }}
-    {{- if $realm.ssoSessionIdleTimeout }}
-      {{- $_ := set $realmConfig "ssoSessionIdleTimeout" $realm.ssoSessionIdleTimeout }}
-    {{- end }}
-    {{- if $realm.ssoSessionMaxLifespan }}
-      {{- $_ := set $realmConfig "ssoSessionMaxLifespan" $realm.ssoSessionMaxLifespan }}
-    {{- end }}
-    {{- if $realm.accessTokenLifespan }}
-      {{- $_ := set $realmConfig "accessTokenLifespan" $realm.accessTokenLifespan }}
-    {{- end }}
-    {{- if $realm.clients }}
-      {{- $_ := set $realmConfig "clients" $realm.clients }}
-    {{- end }}
-    {{- if $realm.roles }}
-      {{- $_ := set $realmConfig "roles" $realm.roles }}
-    {{- end }}
-    {{- if $realm.users }}
-      {{- $_ := set $realmConfig "users" $realm.users }}
-    {{- end }}
-    {{ $realmConfig | toJson | nindent 4 }}
-{{- end }}
+  realm.json: |
+    {{- .Files.Get "realm.json" | nindent 4 }}
 {{- end }}

--- a/keycloak/helm/templates/deployment.yaml
+++ b/keycloak/helm/templates/deployment.yaml
@@ -97,12 +97,10 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
           {{- end }}
           {{- if .Values.realmImport.enabled }}
-          {{- range .Values.realmImport.realms }}
-            - name: realm-import-{{ .realm }}
-              mountPath: /opt/keycloak/data/import/{{ .realm }}-realm.json
-              subPath: {{ .realm }}-realm.json
+            - name: realm-import
+              mountPath: /opt/keycloak/data/import/realm.json
+              subPath: realm.json
               readOnly: true
-          {{- end }}
           {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -116,11 +114,9 @@ spec:
             claimName: {{ include "keycloak.fullname" . }}-data
         {{- end }}
         {{- if .Values.realmImport.enabled }}
-        {{- range .Values.realmImport.realms }}
-        - name: realm-import-{{ .realm }}
+        - name: realm-import
           configMap:
-            name: {{ include "keycloak.fullname" $ }}-realm-{{ .realm }}
-        {{- end }}
+            name: {{ include "keycloak.fullname" . }}-realm-import
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/keycloak/helm/templates/deployment.yaml
+++ b/keycloak/helm/templates/deployment.yaml
@@ -38,9 +38,14 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.args }}
+          {{- if or .Values.args .Values.realmImport.enabled }}
           args:
+            {{- with .Values.args }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.realmImport.enabled }}
+            - --import-realm
+            {{- end }}
           {{- end }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
@@ -85,21 +90,38 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.persistence.enabled .Values.volumeMounts }}
+          {{- if or .Values.persistence.enabled .Values.realmImport.enabled .Values.volumeMounts }}
           volumeMounts:
           {{- if .Values.persistence.enabled }}
             - name: keycloak-data
               mountPath: {{ .Values.persistence.mountPath }}
           {{- end }}
+          {{- if .Values.realmImport.enabled }}
+          {{- range .Values.realmImport.realms }}
+            - name: realm-import-{{ .realm }}
+              mountPath: /opt/keycloak/data/import/{{ .realm }}-realm.json
+              subPath: {{ .realm }}-realm.json
+              readOnly: true
+          {{- end }}
+          {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
-      {{- if .Values.persistence.enabled }}
+      {{- if or .Values.persistence.enabled .Values.realmImport.enabled }}
       volumes:
+        {{- if .Values.persistence.enabled }}
         - name: keycloak-data
           persistentVolumeClaim:
             claimName: {{ include "keycloak.fullname" . }}-data
+        {{- end }}
+        {{- if .Values.realmImport.enabled }}
+        {{- range .Values.realmImport.realms }}
+        - name: realm-import-{{ .realm }}
+          configMap:
+            name: {{ include "keycloak.fullname" $ }}-realm-{{ .realm }}
+        {{- end }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/keycloak/helm/templates/deployment.yaml
+++ b/keycloak/helm/templates/deployment.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "keycloak.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "keycloak.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "keycloak.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+            {{- if .Values.secret.dbEnabled }}
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL
+              valueFrom:
+                secretKeyRef:
+                  key: db-url
+                  name: keycloak-db
+            - name: KC_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: db-username
+                  name: keycloak-db
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: db-password
+                  name: keycloak-db
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            - name: https
+              containerPort: {{ .Values.service.httpsPort }}
+              protocol: TCP
+            - name: management
+              containerPort: 9000
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.persistence.enabled .Values.volumeMounts }}
+          volumeMounts:
+          {{- if .Values.persistence.enabled }}
+            - name: keycloak-data
+              mountPath: {{ .Values.persistence.mountPath }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: keycloak-data
+          persistentVolumeClaim:
+            claimName: {{ include "keycloak.fullname" . }}-data
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/keycloak/helm/templates/pvc.yaml
+++ b/keycloak/helm/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "keycloak.fullname" . }}-data
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/keycloak/helm/templates/route.yaml
+++ b/keycloak/helm/templates/route.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.route.enabled }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "keycloak.fullname" . }}
+    weight: 100
+  port:
+    targetPort: http
+  wildcardPolicy: None
+  {{- if .Values.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+{{- end }}

--- a/keycloak/helm/templates/secret.yaml
+++ b/keycloak/helm/templates/secret.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-admin
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+type: Opaque
+data:
+  admin-user: {{ .Values.secret.adminUser | b64enc | quote }}
+  admin-password: {{ .Values.secret.adminPassword | b64enc | quote }}
+---
+{{- if .Values.secret.dbEnabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-db
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+type: Opaque
+data:
+  db-url: {{ .Values.secret.dbUrl | b64enc | quote }}
+  db-username: {{ .Values.secret.dbUsername | b64enc | quote }}
+  db-password: {{ .Values.secret.dbPassword | b64enc | quote }}
+{{- end }}

--- a/keycloak/helm/templates/service.yaml
+++ b/keycloak/helm/templates/service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.httpsPort }}
+      targetPort: https
+      protocol: TCP
+      name: https
+  selector:
+    {{- include "keycloak.selectorLabels" . | nindent 4 }}

--- a/keycloak/helm/values.yaml
+++ b/keycloak/helm/values.yaml
@@ -1,10 +1,8 @@
-# Default values for keycloak.
 replicaCount: 1
 
 image:
   repository: quay.io/keycloak/keycloak
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
   tag: "25.0.6"
 
 imagePullSecrets: []
@@ -27,15 +25,10 @@ service:
   port: 8080
   httpsPort: 8443
 
-# Keycloak start command arguments
-# For development without external DB, use 'start-dev' with proxy configuration
-# For production with external DB, use 'start' with --optimized and full hostname config
 args:
   - start-dev
   - --proxy-headers=xforwarded
 
-# Environment variables for Keycloak configuration
-# Note: When dbEnabled is false, additional DB env vars will be added via templates
 env:
   - name: KEYCLOAK_ADMIN
     valueFrom:
@@ -52,9 +45,6 @@ env:
   - name: KC_METRICS_ENABLED
     value: "true"
 
-# Health check probes
-# Note: In dev mode, health endpoints are on management port 9000
-# In production mode with --optimized, they are on the main port 8080
 livenessProbe:
   httpGet:
     path: /health/live
@@ -81,7 +71,6 @@ resources:
     cpu: 500m
     memory: 1Gi
 
-# Persistent volume for Keycloak data (themes, providers, etc.)
 persistence:
   enabled: false
   storageClass: ""
@@ -97,17 +86,14 @@ tolerations: []
 
 affinity: {}
 
-# Admin credentials stored in secret
 secret:
   adminUser: admin
   adminPassword: admin
-  # Database connection (optional - can use external DB)
   dbEnabled: false
   dbUrl: "jdbc:postgresql://postgres:5432/keycloak"
   dbUsername: keycloak
   dbPassword: keycloak
 
-# OpenShift Route configuration
 route:
   enabled: true
   host: ""
@@ -116,20 +102,15 @@ route:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
 
-# Realm import configuration
-# Keycloak will import these realms on startup using --import-realm
-# This eliminates the need for a separate Job to configure realms/users/clients
 realmImport:
   enabled: true
   realms:
     - realm: "ryans-realm"
       enabled: true
       displayName: "Ryan's Realm"
-      # SSO Session and Token Lifespans (in seconds)
       ssoSessionIdleTimeout: 1800
       ssoSessionMaxLifespan: 36000
       accessTokenLifespan: 300
-      # Clients
       clients:
         - clientId: "ryans-app"
           enabled: true
@@ -143,23 +124,12 @@ realmImport:
             - "https://ryans-app.example.com"
           protocol: "openid-connect"
           standardFlowEnabled: true
-        # Example confidential client (e.g. backend service)
-        # - clientId: "my-backend"
-        #   enabled: true
-        #   publicClient: false
-        #   clientAuthenticatorType: "client-secret"
-        #   secret: "change-me"
-        #   serviceAccountsEnabled: true
-        #   directAccessGrantsEnabled: true
-        #   protocol: "openid-connect"
-      # Realm Roles
       roles:
         realm:
           - name: "admin"
             description: "Administrator role"
           - name: "user"
             description: "Regular user role"
-      # Users
       users:
         - username: "testuser"
           enabled: true
@@ -173,16 +143,3 @@ realmImport:
               temporary: false
           realmRoles:
             - "user"
-        # - username: "admin-user"
-        #   enabled: true
-        #   emailVerified: true
-        #   firstName: "Admin"
-        #   lastName: "User"
-        #   email: "admin@example.com"
-        #   credentials:
-        #     - type: "password"
-        #       value: "adminpassword"
-        #       temporary: false
-        #   realmRoles:
-        #     - "admin"
-        #     - "user"

--- a/keycloak/helm/values.yaml
+++ b/keycloak/helm/values.yaml
@@ -1,0 +1,117 @@
+# Default values for keycloak.
+replicaCount: 1
+
+image:
+  repository: quay.io/keycloak/keycloak
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "25.0.6"
+
+imagePullSecrets: []
+
+nameOverride: "keycloak"
+fullnameOverride: "keycloak"
+
+serviceAccount:
+  create: false
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+  httpsPort: 8443
+
+# Keycloak start command arguments
+# For development without external DB, use 'start-dev' with proxy configuration
+# For production with external DB, use 'start' with --optimized and full hostname config
+args:
+  - start-dev
+  - --proxy-headers=xforwarded
+
+# Environment variables for Keycloak configuration
+# Note: When dbEnabled is false, additional DB env vars will be added via templates
+env:
+  - name: KEYCLOAK_ADMIN
+    valueFrom:
+      secretKeyRef:
+        key: admin-user
+        name: keycloak-admin
+  - name: KEYCLOAK_ADMIN_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        key: admin-password
+        name: keycloak-admin
+  - name: KC_HEALTH_ENABLED
+    value: "true"
+  - name: KC_METRICS_ENABLED
+    value: "true"
+
+# Health check probes
+# Note: In dev mode, health endpoints are on management port 9000
+# In production mode with --optimized, they are on the main port 8080
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: 9000
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: 9000
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 1Gi
+
+# Persistent volume for Keycloak data (themes, providers, etc.)
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  mountPath: /opt/keycloak/data
+
+volumeMounts: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Admin credentials stored in secret
+secret:
+  adminUser: admin
+  adminPassword: admin
+  # Database connection (optional - can use external DB)
+  dbEnabled: false
+  dbUrl: "jdbc:postgresql://postgres:5432/keycloak"
+  dbUsername: keycloak
+  dbPassword: keycloak
+
+# OpenShift Route configuration
+route:
+  enabled: true
+  host: ""
+  tls:
+    enabled: true
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/keycloak/helm/values.yaml
+++ b/keycloak/helm/values.yaml
@@ -115,3 +115,74 @@ route:
     enabled: true
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
+
+# Realm import configuration
+# Keycloak will import these realms on startup using --import-realm
+# This eliminates the need for a separate Job to configure realms/users/clients
+realmImport:
+  enabled: true
+  realms:
+    - realm: "ryans-realm"
+      enabled: true
+      displayName: "Ryan's Realm"
+      # SSO Session and Token Lifespans (in seconds)
+      ssoSessionIdleTimeout: 1800
+      ssoSessionMaxLifespan: 36000
+      accessTokenLifespan: 300
+      # Clients
+      clients:
+        - clientId: "ryans-app"
+          enabled: true
+          publicClient: true
+          directAccessGrantsEnabled: true
+          redirectUris:
+            - "http://localhost:3000/*"
+            - "https://ryans-app.example.com/*"
+          webOrigins:
+            - "http://localhost:3000"
+            - "https://ryans-app.example.com"
+          protocol: "openid-connect"
+          standardFlowEnabled: true
+        # Example confidential client (e.g. backend service)
+        # - clientId: "my-backend"
+        #   enabled: true
+        #   publicClient: false
+        #   clientAuthenticatorType: "client-secret"
+        #   secret: "change-me"
+        #   serviceAccountsEnabled: true
+        #   directAccessGrantsEnabled: true
+        #   protocol: "openid-connect"
+      # Realm Roles
+      roles:
+        realm:
+          - name: "admin"
+            description: "Administrator role"
+          - name: "user"
+            description: "Regular user role"
+      # Users
+      users:
+        - username: "testuser"
+          enabled: true
+          emailVerified: true
+          firstName: "Test"
+          lastName: "User"
+          email: "testuser@example.com"
+          credentials:
+            - type: "password"
+              value: "testpassword"
+              temporary: false
+          realmRoles:
+            - "user"
+        # - username: "admin-user"
+        #   enabled: true
+        #   emailVerified: true
+        #   firstName: "Admin"
+        #   lastName: "User"
+        #   email: "admin@example.com"
+        #   credentials:
+        #     - type: "password"
+        #       value: "adminpassword"
+        #       temporary: false
+        #   realmRoles:
+        #     - "admin"
+        #     - "user"

--- a/keycloak/helm/values.yaml
+++ b/keycloak/helm/values.yaml
@@ -103,43 +103,4 @@ route:
     insecureEdgeTerminationPolicy: Redirect
 
 realmImport:
-  enabled: false
-  realms:
-    - realm: "ryans-realm"
-      enabled: true
-      displayName: "Ryan's Realm"
-      ssoSessionIdleTimeout: 1800
-      ssoSessionMaxLifespan: 36000
-      accessTokenLifespan: 300
-      clients:
-        - clientId: "ryans-app"
-          enabled: true
-          publicClient: true
-          directAccessGrantsEnabled: true
-          redirectUris:
-            - "http://localhost:3000/*"
-            - "https://ryans-app.example.com/*"
-          webOrigins:
-            - "http://localhost:3000"
-            - "https://ryans-app.example.com"
-          protocol: "openid-connect"
-          standardFlowEnabled: true
-      roles:
-        realm:
-          - name: "admin"
-            description: "Administrator role"
-          - name: "user"
-            description: "Regular user role"
-      users:
-        - username: "testuser"
-          enabled: true
-          emailVerified: true
-          firstName: "Test"
-          lastName: "User"
-          email: "testuser@example.com"
-          credentials:
-            - type: "password"
-              value: "testpassword"
-              temporary: false
-          realmRoles:
-            - "user"
+  enabled: true

--- a/keycloak/helm/values.yaml
+++ b/keycloak/helm/values.yaml
@@ -103,7 +103,7 @@ route:
     insecureEdgeTerminationPolicy: Redirect
 
 realmImport:
-  enabled: true
+  enabled: false
   realms:
     - realm: "ryans-realm"
       enabled: true


### PR DESCRIPTION
Enable Keycloak
- Enable keycloak with and without PG backing database
- Enable user creation on startup
- Enable relm creation on startup. 
- Enable role creation roles on startup. 

<img width="1251" height="529" alt="image" src="https://github.com/user-attachments/assets/42f67a14-1811-4a68-b15a-807dbe0640e3" />

<img width="1251" height="529" alt="image" src="https://github.com/user-attachments/assets/314c377a-f5ea-4986-bd10-f3b8de34a59d" />

Based on https://github.com/rh-ai-quickstart/ai-architecture-charts/pull/128/changes
