### PR TITLE
feat(mcp-servers): optional extraContainers for multi-container MCP pods

### DIFF
--- a/mcp-servers/helm/templates/deployment.yaml
+++ b/mcp-servers/helm/templates/deployment.yaml
@@ -99,5 +99,8 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- with $server.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/mcp-servers/helm/values.yaml
+++ b/mcp-servers/helm/values.yaml
@@ -48,6 +48,14 @@ mcp-servers:
     # Optional: Limit which tools are available
     # env:
     #   GITHUB_TOOLS: "get_file_contents,issue_read,create_pull_request"
+    #
+    # Optional extraContainers: extra containers in the same pod (standard
+    # Kubernetes container maps). Only rendered for Deployment mode, not for
+    # Toolhive MCPServer resources.
+    # extraContainers:
+    #   - name: example-sidecar
+    #     image: registry.example/sidecar:tag
+    #     imagePullPolicy: IfNotPresent
 
   openshift-mcp:
     enabled: false
@@ -96,3 +104,6 @@ mcp-servers:
       # Optional: Enable message posting and logging
       # SLACK_MCP_ADD_MESSAGE_TOOL: "true"  # or channel list, or !channel to exclude
       # SLACK_MCP_LOG_LEVEL: "info"  # debug, info, warn, error
+
+  # Optional extraContainers: list of standard Kubernetes container maps, appended in
+  # Deployment pods only (not used for Toolhive MCPServer resources).

--- a/mcp-servers/helm/values.yaml
+++ b/mcp-servers/helm/values.yaml
@@ -104,6 +104,3 @@ mcp-servers:
       # Optional: Enable message posting and logging
       # SLACK_MCP_ADD_MESSAGE_TOOL: "true"  # or channel list, or !channel to exclude
       # SLACK_MCP_LOG_LEVEL: "info"  # debug, info, warn, error
-
-  # Optional extraContainers: list of standard Kubernetes container maps, appended in
-  # Deployment pods only (not used for Toolhive MCPServer resources).


### PR DESCRIPTION
Add per-server extraContainers (YAML list of standard container specs) appended to the Deployment pod after the main MCP container. Enables sidecars (e.g. a second MCP on 127.0.0.1) without chart forks.

Made-with: Cursor