### PR TITLE
fix: remove instructLab field from DSPA template

### DIFF
--- a/configure-pipeline/helm/templates/pipeline.yaml
+++ b/configure-pipeline/helm/templates/pipeline.yaml
@@ -11,9 +11,6 @@ spec:
     deploy: true
     enableOauth: true
     enableSamplePipeline: false
-    managedPipelines:
-      instructLab:
-        state: Removed
   database:
     disableHealthCheck: false
     mariaDB:


### PR DESCRIPTION
The `managedPipelines.instructLab` field was removed from the DataSciencePipelinesApplication CRD in data-science-pipelines-operator PR #916 (Sep 2025) and the managedPipelines struct was restructured in PR #991 (Mar 2026) with generic fields (image, pipelines, resources, volumeSizeLimit).

OSAI 3.4.0 GA ships the new CRD schema which does not include the `instructLab` sub-field. The chart's `state: Removed` directive was a no-op anyway — the InstructLab pipeline was already removed from the operator entirely. Deploying with this field on OSAI 3.4.0 GA fails with: "field not declared in schema".

Fixes deployment on OSAI 3.4.0 GA clusters.