### PR TITLE
chore(upgrade): Disable managed pipeline overrides in the configure-pipeline subchart.

### DIFF
--- a/configure-pipeline/helm/templates/pipeline.yaml
+++ b/configure-pipeline/helm/templates/pipeline.yaml
@@ -11,9 +11,10 @@ spec:
     deploy: true
     enableOauth: true
     enableSamplePipeline: false
+    {{- with .Values.managedPipelines }}
     managedPipelines:
-      instructLab:
-        state: Removed
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   database:
     disableHealthCheck: false
     mariaDB:


### PR DESCRIPTION
What it does

1) The configure-pipeline subchart deploys a DataSciencePipelinesApplication (DSPA) that backs Kubeflow Pipelines in OpenShift AI. OpenShift AI 3.4 introduced managed pipelines — platform-provided pipelines such as InstructLab that the DSPA can control via a managedPipelines spec field.

Why

1) Disabling this override avoids injecting OpenShift AI 3.4+-specific managed pipeline configuration into the DSPA, which keeps the deployment simpler and avoids potential compatibility issues on clusters where that field is unsupported or where you do not want to alter platform-managed pipelines.