### PR TITLE
WIP: feat(ogx_ai): Introduces a new ogx-ai helm chart and add backwards compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Architecture Charts
 
-A comprehensive collection of Helm charts for deploying end-to-end AI/ML infrastructure on OpenShift, featuring LlamaStack orchestration, model serving, vector databases, and supporting services.
+A comprehensive collection of Helm charts for deploying end-to-end AI/ML infrastructure on OpenShift, featuring LlamaStack/OGX orchestration, model serving, vector databases, and supporting services.
 
 ## Overview
 
@@ -16,6 +16,16 @@ Comprehensive AI orchestration platform that provides a unified API for multiple
 **Key Features:**
 - Multi-provider model support (local, remote, VertexAI)
 - Safety shields with Llama Guard and other safety models
+- AI agent capabilities with persistent memory
+- Automatic model discovery and URL generation
+
+#### [OGX](./ogx-ai/README.md)
+Successor chart for [OGX](https://github.com/ogx-ai/ogx) (formerly Llama Stack). Provides the same orchestration role as the llama-stack chart with OpenAI-compatible APIs, multi-provider model support, and MCP-style tool integration. Use **ogx-ai** for new deployments; **llama-stack** remains available for backwards compatibility.
+
+**Key Features:**
+- OpenAI-compatible agentic API server
+- Multi-provider model support (local, remote, VertexAI)
+- Content moderation via OpenAI-compatible `/v1/moderations` endpoint
 - AI agent capabilities with persistent memory
 - Automatic model discovery and URL generation
 
@@ -98,10 +108,10 @@ Model Context Protocol servers that provide external tools and capabilities to A
 - Weather information services
 - Server-Sent Events (SSE) endpoints
 - Custom tool development framework
-- Integration with LlamaStack agents
+- Integration with LlamaStack and OGX agents
 
 #### [Oracle SQLcl MCP](./oracle-sqlcl/helm/README.md)
-MCP server that exposes Oracle SQLcl capabilities to AI agents via Toolhive, enabling database tooling and interactions from LlamaStack and compatible clients.
+MCP server that exposes Oracle SQLcl capabilities to AI agents via Toolhive, enabling database tooling and interactions from LlamaStack, OGX, and compatible clients.
 
 **Key Features:**
 - Execute SQL/PLSQL against Oracle databases via Model Context Protocol
@@ -132,8 +142,11 @@ helm install minio ./minio/helm
 helm install llm-service ./llm-service/helm \
   --set models.llama-3-2-3b-instruct.enabled=true
 
-# 4. Deploy LlamaStack orchestration
+# 4. Deploy orchestration (llama-stack or ogx-ai)
 helm install llama-stack ./llama-stack/helm \
+  --set models.llama-3-2-3b-instruct.enabled=true
+# or, for new deployments:
+helm install ogx-ai ./ogx-ai/helm \
   --set models.llama-3-2-3b-instruct.enabled=true
 
 # 5. Deploy ingestion pipeline
@@ -163,15 +176,18 @@ helm install llm-service ./llm-service/helm \
   --set models.llama-3-2-3b-instruct.enabled=true
 helm install llama-stack ./llama-stack/helm \
   --set models.llama-3-2-3b-instruct.enabled=true
+# or, for new deployments:
+helm install ogx-ai ./ogx-ai/helm \
+  --set models.llama-3-2-3b-instruct.enabled=true
 ```
 
 ## Integration Patterns
 
-### LlamaStack + LLM Service
-LlamaStack provides orchestration while LLM Service handles model inference:
+### LlamaStack / OGX + LLM Service
+The llama-stack or ogx-ai chart provides orchestration while LLM Service handles model inference:
 - LLM Service deploys models as InferenceServices
-- LlamaStack automatically discovers and configures model endpoints
-- Unified API access through LlamaStack
+- LlamaStack/OGX automatically discovers and configures model endpoints
+- Unified API access through LlamaStack or OGX
 
 ### Vector Storage Integration
 Both PGVector and Oracle 23ai can serve as vector databases:
@@ -189,7 +205,7 @@ Ingestion Pipeline supports various data sources:
 
 ```mermaid
 graph TB
-    LS[LlamaStack] --> LLM[LLM Service]
+    LS[LlamaStack / OGX] --> LLM[LLM Service]
     LS --> PG[PGVector]
     LS --> MCP[MCP Servers]
     
@@ -216,7 +232,7 @@ graph TB
 ## Monitoring and Observability
 
 - **Prometheus Integration**: Many components support Prometheus metrics
-- **OpenTelemetry**: LlamaStack supports distributed tracing
+- **OpenTelemetry**: LlamaStack and OGX support distributed tracing
 - **Logging**: All components provide structured logging
 - **Health Checks**: Kubernetes-native health and readiness probes
 
@@ -307,6 +323,10 @@ dependencies:
     version: "0.2.18"
     repository: "file://../ai-architecture-charts/llama-stack/helm"
   
+  - name: ogx-ai
+    version: "0.8.6"
+    repository: "file://../ai-architecture-charts/ogx-ai/helm"
+  
   - name: ingestion-pipeline
     version: "0.2.18"
     repository: "file://../ai-architecture-charts/ingestion-pipeline/helm"
@@ -347,6 +367,14 @@ llama-stack:
     llama-guard-3-8b:
       enabled: true
       registerShield: true
+
+# Use ogx-ai instead of llama-stack for new deployments (typically one or the other)
+ogx-ai:
+  models:
+    llama-3-2-3b-instruct:
+      enabled: true
+    llama-guard-3-8b:
+      enabled: true
 
 ingestion-pipeline:
   defaultPipeline:
@@ -424,7 +452,7 @@ minio:
     bucket: "ai-documents"
 
 # Global models will be merged with local configurations
-# Both llm-service and llama-stack will use the global.models settings
+# llm-service, llama-stack, and ogx-ai will use the global.models settings
 ```
 
 ### Deployment Workflow
@@ -555,6 +583,7 @@ Where:
 Examples:
 - `ingestion-pipeline-0.2.18`
 - `llama-stack-0.3.0`
+- `ogx-ai-0.8.6`
 - `mcp-servers-0.1.0`
 
 ### Container Image Tags

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -22,6 +22,7 @@ Examples:
 ingestion-pipeline-0.2.18
 ingestion-pipeline-0.2.19
 llama-stack-0.3.0
+ogx-ai-1.0.0
 mcp-servers-0.1.0
 ```
 
@@ -52,6 +53,7 @@ Follow [Semantic Versioning](https://semver.org/):
 
 **Dependency Versions:**
 - LlamaStack version is configured in `llama-stack/helm/values.yaml`
+- OGX version is configured in `ogx-ai/helm/values.yaml`
 - LlamaStack client version is pinned in `ingestion-pipeline/src/requirements.txt`
 - No build args or templating needed
 
@@ -96,6 +98,7 @@ Examples:
 - `ingestion-pipeline-0.2.18`
 - `ingestion-pipeline-0.2.19`
 - `llama-stack-0.3.0`
+- `ogx-ai-0.8.6`
 - `mcp-servers-0.1.0`
 
 You can list all tags for a component:
@@ -206,6 +209,13 @@ Dependency versions are managed directly in their configuration files:
 llamastackVersion: "0.0.58"  # Update the LlamaStack container version
 ```
 
+**OGX version:**
+```yaml
+# ogx-ai/helm/values.yaml
+image:
+  tag: "0.6.0"  # Update the OGX container version
+```
+
 **LlamaStack client version:**
 ```txt
 # ingestion-pipeline/src/requirements.txt
@@ -307,6 +317,7 @@ The chart `version` field determines the Helm package version, while `appVersion
 |-----------|------------------|-----------------|-------------------|
 | ingestion-pipeline | Yes (via build.yaml) | 0.2.18 | LlamaStack client |
 | llama-stack | No | 0.2.18 | LlamaStack upstream |
+| ogx-ai | No | 0.8.6 | OGX upstream |
 | mcp-servers | Yes (via build.yaml) | 0.1.0 | MCP protocol |
 | llm-service | No | 0.1.0 | N/A |
 | pgvector | No | 0.1.0 | PostgreSQL/pgvector |
@@ -401,6 +412,7 @@ That's fine! Each component versions independently:
 ```
 ingestion-pipeline-0.3.0  (manually bumped to minor)
 llama-stack-0.2.19        (auto-incremented patch)
+ogx-ai-0.8.7              (auto-incremented patch)
 ```
 
 ## Future Enhancements

--- a/configure-pipeline/README.md
+++ b/configure-pipeline/README.md
@@ -341,7 +341,7 @@ This chart has the following subchart dependency:
 This chart works well with other components in the AI architecture:
 
 - **ingestion-pipeline**: For data processing workflows
-- **llama-stack**: For LLM inference capabilities  
+- **llama-stack** / **ogx-ai**: For LLM inference and orchestration capabilities
 - **pgvector**: For vector storage
 - **minio**: For object storage
 

--- a/configure-pipeline/helm/templates/notebook.yaml
+++ b/configure-pipeline/helm/templates/notebook.yaml
@@ -63,6 +63,11 @@ spec:
                 secretKeyRef:
                   name: rag-pipeline-secrets
                   key: LLAMASTACK_BASE_URL
+            - name: OGX_AI_BASE_URL # TODO: update to use ogx-ai service name
+              valueFrom:
+                secretKeyRef:
+                  name: rag-pipeline-secrets
+                  key: OGX_AI_BASE_URL # TODO: update to use ogx-ai service name
             - name: DS_PIPELINE_URL
               valueFrom:
                 secretKeyRef:

--- a/configure-pipeline/helm/templates/notebook.yaml
+++ b/configure-pipeline/helm/templates/notebook.yaml
@@ -63,11 +63,11 @@ spec:
                 secretKeyRef:
                   name: rag-pipeline-secrets
                   key: LLAMASTACK_BASE_URL
-            - name: OGX_AI_BASE_URL # TODO: update to use ogx-ai service name
+            - name: OGX_AI_BASE_URL
               valueFrom:
                 secretKeyRef:
                   name: rag-pipeline-secrets
-                  key: OGX_AI_BASE_URL # TODO: update to use ogx-ai service name
+                  key: OGX_AI_BASE_URL
             - name: DS_PIPELINE_URL
               valueFrom:
                 secretKeyRef:

--- a/configure-pipeline/helm/templates/rag-pipeline-secrets.yaml
+++ b/configure-pipeline/helm/templates/rag-pipeline-secrets.yaml
@@ -8,7 +8,7 @@ stringData:
   MINIO_ENDPOINT: "http://{{ .Values.minio.secret.host }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.minio.secret.port }}"
   MINIO_ACCESS_KEY: "{{ .Values.minio.secret.user }}"
   MINIO_SECRET_KEY: "{{ .Values.minio.secret.password }}"
-  LLAMASTACK_BASE_URL: "http://llamastack.{{ .Release.Namespace }}.svc.cluster.local:8321" # TODO: update to use ogx-ai service name
-  OGX_AI_BASE_URL: "http://ogx-ai.{{ .Release.Namespace }}.svc.cluster.local:8321" # TODO: update to use ogx-ai service name
+  LLAMASTACK_BASE_URL: "http://llamastack.{{ .Release.Namespace }}.svc.cluster.local:8321"
+  OGX_AI_BASE_URL: "http://ogx-ai.{{ .Release.Namespace }}.svc.cluster.local:8321"
   DS_PIPELINE_URL: "https://ds-pipeline-dspa.{{ .Release.Namespace }}.svc.cluster.local:8888"
 {{- end }}

--- a/configure-pipeline/helm/templates/rag-pipeline-secrets.yaml
+++ b/configure-pipeline/helm/templates/rag-pipeline-secrets.yaml
@@ -8,6 +8,7 @@ stringData:
   MINIO_ENDPOINT: "http://{{ .Values.minio.secret.host }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.minio.secret.port }}"
   MINIO_ACCESS_KEY: "{{ .Values.minio.secret.user }}"
   MINIO_SECRET_KEY: "{{ .Values.minio.secret.password }}"
-  LLAMASTACK_BASE_URL: "http://llamastack.{{ .Release.Namespace }}.svc.cluster.local:8321"
+  LLAMASTACK_BASE_URL: "http://llamastack.{{ .Release.Namespace }}.svc.cluster.local:8321" # TODO: update to use ogx-ai service name
+  OGX_AI_BASE_URL: "http://ogx-ai.{{ .Release.Namespace }}.svc.cluster.local:8321" # TODO: update to use ogx-ai service name
   DS_PIPELINE_URL: "https://ds-pipeline-dspa.{{ .Release.Namespace }}.svc.cluster.local:8888"
 {{- end }}

--- a/ingestion-pipeline/README.md
+++ b/ingestion-pipeline/README.md
@@ -29,7 +29,7 @@ This chart supports multiple concurrent pipelines, allowing you to:
 - External dependencies:
   - MinIO instance for S3 storage
   - Vector database (PGVector recommended)
-  - LlamaStack for embeddings (optional)
+  - LlamaStack or OGX for embeddings (optional)
 
 ## Installation
 
@@ -435,7 +435,7 @@ This chart integrates with:
 
 - **MinIO**: Object storage for documents
 - **PGVector**: Vector database for embeddings
-- **LlamaStack**: LLM inference and embeddings
+- **LlamaStack / OGX**: LLM inference and embeddings
 - **OpenShift AI**: Pipeline orchestration and notebooks
 
 ## API Reference

--- a/ingestion-pipeline/helm/templates/_helpers.tpl
+++ b/ingestion-pipeline/helm/templates/_helpers.tpl
@@ -107,3 +107,28 @@ Prepare pipeline data for API call
 -}}
 {{- merge $base $sourceData | toJson -}}
 {{- end }}
+
+{{/*
+Kubernetes Service hostname for the AI gateway (llama-stack or ogx-ai).
+*/}}
+{{- define "ingestion-pipeline.gatewayServiceHost" -}}
+{{- if eq .Values.clientDependency "ogx-ai" -}}
+ogx-ai
+{{- else -}}
+llamastack
+{{- end -}}
+{{- end }}
+
+{{/*
+In-cluster base URL for the AI gateway API.
+*/}}
+{{- define "ingestion-pipeline.gatewayBaseUrl" -}}
+http://{{ include "ingestion-pipeline.gatewayServiceHost" . }}.{{ .Release.Namespace }}.svc.cluster.local:8321
+{{- end }}
+
+{{/*
+Short in-namespace URL for init-container health checks.
+*/}}
+{{- define "ingestion-pipeline.gatewayModelsUrl" -}}
+http://{{ include "ingestion-pipeline.gatewayServiceHost" . }}:8321/v1/models
+{{- end }}

--- a/ingestion-pipeline/helm/templates/default-pipeline-job.yaml
+++ b/ingestion-pipeline/helm/templates/default-pipeline-job.yaml
@@ -40,7 +40,7 @@ spec:
               done
               echo "Ingestion pipeline service ready"
 
-              url="http://llamastack:8321/v1/models"
+              url="{{ include "ingestion-pipeline.gatewayModelsUrl" . }}"
               if [ ! -z ${LLAMA_STACK_AUTH_USER} ]; then
                 headers="-H \"X-Forwarded-User: ${LLAMA_STACK_AUTH_USER}\" -H \"Authorization: Bearer \$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\""
               fi

--- a/ingestion-pipeline/helm/templates/deployment.yaml
+++ b/ingestion-pipeline/helm/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
               done
               echo "Data science pipeline configured"
 
-              url="http://llamastack:8321/v1/models"
+              url="{{ include "ingestion-pipeline.gatewayModelsUrl" . }}"
               if [ ! -z ${LLAMA_STACK_AUTH_USER} ]; then
                 headers="-H \"X-Forwarded-User: ${LLAMA_STACK_AUTH_USER}\" -H \"Authorization: Bearer \$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\""
               fi
@@ -80,7 +80,7 @@ spec:
             - name: INGESTION_PIPELINE_IMAGE
               value: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
             - name: LLAMASTACK_BASE_URL
-              value: "http://llamastack.{{ .Release.Namespace }}.svc.cluster.local:8321"
+              value: {{ include "ingestion-pipeline.gatewayBaseUrl" . | quote }}
             - name: DS_PIPELINE_URL
               value: "https://ds-pipeline-dspa.{{ .Release.Namespace }}.svc.cluster.local:8888"
           {{- if .Values.authUser }}

--- a/ingestion-pipeline/helm/templates/deployment.yaml
+++ b/ingestion-pipeline/helm/templates/deployment.yaml
@@ -89,6 +89,8 @@ spec:
           {{- end }}
             - name: SIGN_DATABASE
               value: {{ .Values.enableSigning | quote }}
+            - name: CLIENT_DEPENDENCY
+              value: {{ .Values.clientDependency | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}

--- a/ingestion-pipeline/helm/values.yaml
+++ b/ingestion-pipeline/helm/values.yaml
@@ -125,9 +125,10 @@ pipelines:
         - "https://arxiv.org/pdf/2408.09869"
         - "https://raw.githubusercontent.com/docling-project/docling/main/tests/data/pdf/2305.03393v1-pg9.pdf"
 
-
-
 authUser: ""
 
 # generate provenance for the knowledge base
 enableSigning: false
+
+# Gateway client dependency: llama-stack (default) or ogx-ai
+clientDependency: llama-stack

--- a/ingestion-pipeline/helm/values.yaml
+++ b/ingestion-pipeline/helm/values.yaml
@@ -130,5 +130,5 @@ authUser: ""
 # generate provenance for the knowledge base
 enableSigning: false
 
-# Gateway client dependency: llama-stack (default) or ogx-ai
+# Gateway client dependency: llama-stack (polls llamastack:8321) or ogx-ai (polls ogx-ai:8321)
 clientDependency: llama-stack

--- a/ingestion-pipeline/src/ingestion_pipeline/pipelines/pipelines.py
+++ b/ingestion-pipeline/src/ingestion_pipeline/pipelines/pipelines.py
@@ -1,7 +1,15 @@
 from kfp import dsl
 from typing import Optional
+import os
 
 from . import tasks
+
+
+def _set_client_dependency_env(task):
+    task.set_env_variable(
+        "CLIENT_DEPENDENCY",
+        os.getenv("CLIENT_DEPENDENCY", "llama-stack"),
+    )
 
 
 def s3_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str, sign_db: str):
@@ -31,6 +39,7 @@ def s3_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str, si
             input_dir=fetch_task.outputs["output_dir"],
             auth_user=auth_user
         )
+        _set_client_dependency_env(store_task)
         store_task.set_caching_options(False)
         pipeline_tasks.append(store_task)
 
@@ -71,6 +80,7 @@ def url_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str, s
             input_dir=fetch_task.outputs["output_dir"],
             auth_user=auth_user
         )
+        _set_client_dependency_env(store_task)
         store_task.set_caching_options(False)
 
         kubernetes.use_secret_as_env(
@@ -104,6 +114,7 @@ def github_pipeline(pipeline_name: str, llamastack_base_url: str, auth_user: str
             input_dir=fetch_task.outputs["output_dir"],
             auth_user=auth_user
         )
+        _set_client_dependency_env(store_task)
         store_task.set_caching_options(False)
 
         for task in (fetch_task, store_task):

--- a/ingestion-pipeline/src/ingestion_pipeline/pipelines/tasks.py
+++ b/ingestion-pipeline/src/ingestion_pipeline/pipelines/tasks.py
@@ -108,13 +108,17 @@ def fetch_from_github(output_dir: Output[Dataset]):
 
 
 @dsl.component(base_image=BASE_IMAGE)
-def store_documents(llamastack_base_url: str, input_dir: Input[Dataset], auth_user: str):
+def store_documents(
+    llamastack_base_url: str,
+    input_dir: Input[Dataset],
+    auth_user: str,
+):
     import ast
     import os
     import time
     from pathlib import Path
 
-    from llama_stack_client import LlamaStackClient
+    from ingestion_pipeline.lib.client import get_client
 
     vector_store_name = os.getenv("VECTOR_STORE_NAME")
 
@@ -142,7 +146,7 @@ def store_documents(llamastack_base_url: str, input_dir: Input[Dataset], auth_us
         except Exception as e:
             print(f"An error occurred: {e}")
 
-    client = LlamaStackClient(
+    client = get_client(
         base_url=llamastack_base_url,
         default_headers=headers,
     )

--- a/ingestion-pipeline/src/requirements.txt
+++ b/ingestion-pipeline/src/requirements.txt
@@ -5,5 +5,6 @@ kfp[kubernetes]==2.14.6
 boto3
 GitPython
 llama-stack-client==0.6.0
+ogx-client==0.1.0
 fire
 requests

--- a/llm-service/README.md
+++ b/llm-service/README.md
@@ -742,7 +742,7 @@ oc delete secret huggingface-secret
 This chart integrates with:
 
 - **OpenShift AI/KServe**: Model serving infrastructure
-- **LlamaStack**: Unified AI stack integration
+- **LlamaStack / OGX**: Unified AI stack integration
 - **Ingestion Pipeline**: Document processing workflows
 - **MCP Servers**: External tool integration
 - **PGVector**: Vector storage for embeddings

--- a/mcp-servers/github-mcp/GITHUB_MCP_README.md
+++ b/mcp-servers/github-mcp/GITHUB_MCP_README.md
@@ -164,7 +164,7 @@ Once started, the server will listen for HTTP requests and handle events as conf
 
 **Note**
 
-In order to get the correct output for the LLM when uysing LLamastack be sure to enable tool outputs. 
+In order to get the correct output for the LLM when using LlamaStack or OGX be sure to enable tool outputs. 
 For example for `LLM=llama-3-2-3b-instruct` you must set:
 
 ```yaml

--- a/minio/README.md
+++ b/minio/README.md
@@ -448,6 +448,9 @@ spec:
     - podSelector:
         matchLabels:
           app: llama-stack
+    - podSelector:
+        matchLabels:
+          app: ogx-ai
     ports:
     - protocol: TCP
       port: 9000
@@ -504,7 +507,7 @@ oc delete secret minio
 This chart integrates with:
 
 - **Ingestion Pipeline**: Document storage and retrieval
-- **LlamaStack**: Model storage and caching
+- **LlamaStack / OGX**: Model storage and caching
 - **Configure Pipeline**: Configuration and template storage
 - **Jupyter Notebooks**: Data science workflows
 

--- a/ogx-ai/README.md
+++ b/ogx-ai/README.md
@@ -1,13 +1,15 @@
-# LlamaStack Helm Chart
+# OGX Helm Chart
 
-> **Note:** For new deployments, use the [ogx-ai](../ogx-ai/README.md) chart, which deploys [OGX](https://github.com/ogx-ai/ogx) (formerly Llama Stack). The llama-stack chart remains available for backwards compatibility.
+This Helm chart deploys **[OGX](https://github.com/ogx-ai/ogx)** (formerly Llama Stack): an OpenAI-compatible, agentic API server that supports multiple LLM providers, remote vLLM endpoints, VertexAI, embeddings, and MCP-style tool integration. See the [project announcement](https://ogx-ai.github.io/blog/from-ogx-ai-to-ogx).
 
-This Helm chart deploys LlamaStack, a comprehensive inference and API server that supports multiple LLM providers including Meta's Llama models, remote vLLM endpoints, VertexAI, and other model providers with support for embeddings and AI agent capabilities.
+> **Chart path:** In this repo the chart still lives under `ogx-ai/helm` for backwards compatibility; the Helm chart name is `ogx-ai`.
 
+> **Service name:** Defaults use `fullnameOverride: ogx-ai`, so the Kubernetes `Service` is `ogx-ai`. Charts or jobs that still call `http://llamastack:8321` should either point at `ogx-ai` or set `fullnameOverride: llamastack` in `values.yaml` until those references are updated.
+-
 ## Overview
 
-The llama-stack chart creates:
-- LlamaStack deployment with configurable models
+The chart creates:
+- OGX deployment with configurable models
 - Service for API access
 - ConfigMap for runtime configuration
 - PVC for model storage and cache
@@ -26,39 +28,39 @@ The llama-stack chart creates:
 
 ### Operator Mode
 All of the above, plus:
-- **llama-stack operator** installed in the cluster
+- **ogx-ai operator** installed in the cluster
 - CRD `llamastackdistributions.llamastack.io` registered (API: `llamastack.io/v1alpha1`)
 
-To install the llama-stack operator:
+To install the ogx-ai operator:
 ```bash
 # Verify CRD is registered
 kubectl get crd llamastackdistributions.llamastack.io
 
 # Verify operator is running
-kubectl get deployment -n llama-stack-operator-system
+kubectl get deployment -n ogx-ai-operator-system
 
 # Check operator version
-kubectl get deployment -n llama-stack-operator-system -o jsonpath='{.items[0].spec.template.spec.containers[0].image}'
+kubectl get deployment -n ogx-ai-operator-system -o jsonpath='{.items[0].spec.template.spec.containers[0].image}'
 ```
 
-**Note**: The llama-stack operator is typically installed as part of OpenDataHub or via a standalone operator deployment. Consult your platform documentation for specific installation steps.
+**Note**: The ogx-ai operator is typically installed as part of OpenDataHub or via a standalone operator deployment. Consult your platform documentation for specific installation steps.
 
 ## Deployment Modes
 
 This chart supports two deployment modes:
 
 1. **Standard Helm Deployment** (default): Deploys traditional Kubernetes resources (Deployment, Service, ConfigMap, etc.)
-2. **Operator-based Deployment**: Deploys a LlamaStackDistribution custom resource managed by the llama-stack operator
+2. **Operator-based Deployment**: Deploys a LlamaStackDistribution custom resource managed by the ogx-ai operator
 
 ### Choosing a Deployment Mode
 
 Use standard Helm deployment when:
 - You want direct control over Kubernetes resources
-- You don't have the llama-stack operator installed
+- You don't have the ogx-ai operator installed
 - You're deploying in environments without CRD support
 
 Use operator-based deployment when:
-- You have the llama-stack operator installed in your cluster
+- You have the ogx-ai operator installed in your cluster
 - You want operator-managed lifecycle and reconciliation
 - You prefer declarative CRD-based configuration
 
@@ -67,15 +69,15 @@ Use operator-based deployment when:
 ### Basic Installation (Standard Mode)
 
 ```bash
-helm install llama-stack ./helm
+helm install ogx ./helm
 ```
 
 ### Installation with Operator Mode
 
-**Prerequisites**: The llama-stack operator must be installed in your cluster.
+**Prerequisites**: The ogx-ai operator must be installed in your cluster.
 
 ```bash
-helm install llama-stack ./helm \
+helm install ogx-ai ./helm \
   --set managedByOperator=true
 ```
 
@@ -86,7 +88,7 @@ This will create a LlamaStackDistribution custom resource instead of traditional
 **Important**: VertexAI requires a Google Cloud service account file. You must provide this file during installation:
 
 ```bash
-helm install llama-stack ./helm \
+helm install ogx-ai ./helm \
   --set vertexai.enabled=true \
   --set vertexai.projectId=your-gcp-project \
   --set vertexai.location=us-central1 \
@@ -99,14 +101,14 @@ The service account file will be mounted at `/var/secrets/gcp-service-account.js
 
 **Standard Mode:**
 ```bash
-helm install llama-stack ./helm \
+helm install ogx-ai ./helm \
   --set models.llama-3-2-3b-instruct.enabled=true \
   --set models.llama-guard-3-8b.enabled=true
 ```
 
 **Operator Mode:**
 ```bash
-helm install llama-stack ./helm \
+helm install ogx-ai ./helm \
   --set managedByOperator=true \
   --set models.llama-3-2-3b-instruct.enabled=true \
   --set models.llama-guard-3-8b.enabled=true
@@ -157,12 +159,11 @@ models:
     # No URL needed - auto-generated as:
     # http://llama-3-2-3b-instruct-predictor.{namespace}.svc.cluster.local:8080/v1
   
-  # Safety model registered as a shield
+  # Optional moderation model (OGX 1.x: use MODERATION_ENDPOINT, not registerShield)
   llama-guard-3-8b:
     id: meta-llama/Llama-Guard-3-8B
     enabled: true
     url: "http://remote-vllm-service:8000/v1"
-    registerShield: true  # Registers this model as a safety shield
   
   # Another local model
   llama-3-1-8b-instruct:
@@ -170,40 +171,22 @@ models:
     enabled: false
 ```
 
-### Safety Shields with registerShield
+### Content moderation (OGX 1.x)
 
-The `registerShield: true` parameter registers a model as a **safety shield** in LlamaStack. Safety shields are specialized models (typically Llama Guard variants) that provide content moderation and safety filtering capabilities:
+The **Safety** and **Shields** APIs were removed in OGX 1.x. Guardrails use an OpenAI-compatible **`/v1/moderations`** endpoint configured on the **responses** provider:
 
-- **Input filtering**: Analyzes user prompts for harmful content before processing
-- **Output filtering**: Reviews model responses for safety violations before returning to users
-- **Content categories**: Detects violence, hate speech, sexual content, self-harm, and other harmful categories
-- **Automatic integration**: Once registered, shields are automatically applied to inference requests
-
-Example safety shield configuration:
 ```yaml
-models:
-  llama-guard-3-1b:
-    id: meta-llama/Llama-Guard-3-1B
-    enabled: true
-    registerShield: true  # This model will act as a safety filter
-  
-  llama-guard-3-8b:
-    id: meta-llama/Llama-Guard-3-8B  
-    enabled: true
-    registerShield: true  # Multiple shields can be registered
-    
-  # Regular inference model (not a shield)
-  llama-3-2-3b-instruct:
-    id: meta-llama/Llama-3.2-3B-Instruct
-    enabled: true
-    # registerShield: false (default)
+providers:
+  responses:
+    - provider_id: builtin
+      provider_type: inline::builtin
+      config:
+        moderation_endpoint: ${env.MODERATION_ENDPOINT:+}
 ```
 
-**Best Practices**:
-- Use safety/moderation models as shields (e.g., Llama Guard, but any safety model works)
-- Register multiple shield models for redundancy
-- Only set `registerShield: true` for safety/moderation models
-- Regular inference models should not be registered as shields
+Set `MODERATION_ENDPOINT` on the deployment (for example to a Llama Guard vLLM moderations URL). The chart default leaves moderation disabled when the variable is unset.
+
+`registerShield` in `values.yaml` model entries is **ignored** by the chart (kept only for backward-compatible values files).
 
 ### VertexAI Configuration
 
@@ -241,7 +224,7 @@ env:
 ```
 
 ### Storage Configuration
-
+<!-- TODO -->
 ```yaml
 volumes:
   - configMap:
@@ -250,7 +233,7 @@ volumes:
     name: run-config-volume
   - name: dot-llama
     persistentVolumeClaim:
-      claimName: llama-stack-data
+      claimName: ogx-ai-data
   - emptyDir: {}
     name: cache
 
@@ -266,12 +249,12 @@ volumeMounts:
 ### Operator Mode Deployment
 
 When `managedByOperator: true`, the chart creates:
-1. A **ConfigMap** (`run-config`) containing the llama-stack configuration (models, providers, etc.)
+1. A **ConfigMap** (`run-config`) containing the ogx-ai configuration (models, providers, etc.)
 2. A **LlamaStackDistribution** custom resource that references this ConfigMap and defines the deployment characteristics
 3. **Secrets** for environment variables and credentials
-4. A **PersistentVolumeClaim** (`llama-stack-data`) for model storage and cache
+4. A **PersistentVolumeClaim** (`ogx-ai-data`) for model storage and cache
 
-The llama-stack operator then reconciles the LlamaStackDistribution CRD to create and manage:
+The ogx-ai operator then reconciles the LlamaStackDistribution CRD to create and manage:
 - Deployment
 - Service  
 - NetworkPolicy (if network access controls are specified)
@@ -386,25 +369,25 @@ kubectl get llamastackdistribution
 kubectl get llsd
 
 # View detailed status including phase, versions, and available replicas
-kubectl get llsd llama-stack -o wide
+kubectl get llsd ogx-ai -o wide
 
 # Describe the resource to see conditions and events
-kubectl describe llsd llama-stack
+kubectl describe llsd ogx-ai
 
 # View the full CRD specification
-kubectl get llsd llama-stack -o yaml
+kubectl get llsd ogx-ai -o yaml
 
 # View the ConfigMap referenced by the CRD
 kubectl get configmap run-config -o yaml
 
 # Check the service URL
-kubectl get llsd llama-stack -o jsonpath='{.status.serviceURL}'
+kubectl get llsd ogx-ai -o jsonpath='{.status.serviceURL}'
 
 # Check the external route URL (if exposeRoute is true)
-kubectl get llsd llama-stack -o jsonpath='{.status.routeURL}'
+kubectl get llsd ogx-ai -o jsonpath='{.status.routeURL}'
 
 # View provider health status
-kubectl get llsd llama-stack -o jsonpath='{.status.distributionConfig.providers}'
+kubectl get llsd ogx-ai -o jsonpath='{.status.distributionConfig.providers}'
 ```
 
 ### Complete Example values.yaml (Standard Mode)
@@ -414,7 +397,7 @@ replicaCount: 1
 rawDeploymentMode: true
 
 image:
-  repository: llamastack/distribution-starter
+  repository: ogx/distribution-starter
   pullPolicy: IfNotPresent
 
 service:
@@ -446,9 +429,9 @@ resources:
 
 # Agent provider configuration
 providers:
-  agents:
-    - provider_id: meta-reference
-      provider_type: inline::meta-reference
+  responses:
+    - provider_id: builtin
+      provider_type: inline::builtin
       config:
         persistence_store:
           type: sqlite
@@ -459,11 +442,11 @@ providers:
 
 ### Accessing the API
 
-The LlamaStack API is available on port 8321:
+The OGX API is available on port 8321:
 
 ```bash
 # Port forward for local access
-oc port-forward svc/llama-stack 8321:8321
+oc port-forward svc/ogx-ai 8321:8321
 
 # Test the API
 curl http://localhost:8321/models
@@ -474,8 +457,8 @@ curl http://localhost:8321/models
 Create a route for external access:
 
 ```bash
-oc expose service llama-stack
-oc get routes llama-stack
+oc expose service ogx-ai
+oc get routes ogx-ai
 ```
 
 ### API Examples
@@ -510,11 +493,11 @@ curl -X POST http://localhost:8321/inference/embeddings \
 
 ### Integration with Vector Database
 
-LlamaStack integrates with PGVector for storing embeddings:
+OGX integrates with PGVector for storing embeddings:
 
 ```bash
 # Check database connection
-oc exec -it deployment/llama-stack -- env | grep POSTGRES
+oc exec -it deployment/ogx-ai -- env | grep POSTGRES
 ```
 
 ## Monitoring and Troubleshooting
@@ -524,46 +507,46 @@ oc exec -it deployment/llama-stack -- env | grep POSTGRES
 **Standard Mode:**
 ```bash
 # Check pod status
-oc get pods -l app.kubernetes.io/name=llama-stack
+oc get pods -l app.kubernetes.io/name=ogx-ai
 
 # Check deployment
-oc get deployment llama-stack
+oc get deployment ogx-ai
 
 # Check service
-oc get svc llama-stack
+oc get svc ogx-ai
 
 # Test health endpoint
-oc exec -it deployment/llama-stack -- curl localhost:8321/health
+oc exec -it deployment/ogx -- curl localhost:8321/health
 ```
 
 **Operator Mode:**
 ```bash
 # Check LlamaStackDistribution resource and its phase
-kubectl get llsd llama-stack -o wide
+kubectl get llsd ogx-ai -o wide
 
 # Check resource status, conditions, and events
-kubectl describe llsd llama-stack
+kubectl describe llsd ogx-ai
 
 # View detailed status information
-kubectl get llsd llama-stack -o jsonpath='{.status}' | jq
+kubectl get llsd ogx-ai -o jsonpath='{.status}' | jq
 
 # Check pods created by the operator
-kubectl get pods -l app.kubernetes.io/managed-by=llama-stack-operator
+kubectl get pods -l app.kubernetes.io/managed-by=ogx-ai-operator
 
 # Check deployment created by operator
-kubectl get deployment -l app.kubernetes.io/managed-by=llama-stack-operator
+kubectl get deployment -l app.kubernetes.io/managed-by=ogx-ai-operator
 
 # Check service created by operator
-kubectl get svc -l app.kubernetes.io/managed-by=llama-stack-operator
+kubectl get svc -l app.kubernetes.io/managed-by=ogx-ai-operator
 
 # Check operator logs for reconciliation errors
-kubectl logs -n llama-stack-operator-system -l app.kubernetes.io/name=llama-stack-operator --tail=100 -f
+kubectl logs -n ogx-ai-operator-system -l app.kubernetes.io/name=ogx-ai-operator --tail=100 -f
 
 # Check the ConfigMap referenced by the CRD
 kubectl get configmap run-config
 
 # Test health endpoint (once pods are running)
-kubectl exec -it deployment/llama-stack -- curl localhost:8321/v1/health
+kubectl exec -it deployment/ogx-ai -- curl localhost:8321/v1/health
 
 # Check network policies (if allowedFrom is configured)
 kubectl get networkpolicy
@@ -578,18 +561,35 @@ oc get route
 
 ```bash
 # Service logs
-oc logs -l app.kubernetes.io/name=llama-stack -f
+oc logs -l app.kubernetes.io/name=ogx -f
 
 # Previous container logs (if crashed)
-oc logs -l app.kubernetes.io/name=llama-stack --previous
+oc logs -l app.kubernetes.io/name=ogx --previous
 
 # Check specific container logs
-oc logs deployment/llama-stack -c llama-stack -f
+oc logs deployment/ogx -c ogx -f
 ```
 
 ### Common Issues
 
-1. **Model Download Failures**:
+1. **`ValueError: invalid literal for int() ... 'tcp://...'` on startup**:
+   - Kubernetes injects `OGX_PORT=tcp://<cluster-ip>:8321` when a Service is named `ogx`, which conflicts with the OGX CLI expecting a numeric port.
+   - This chart sets `enableServiceLinks: false` and an explicit `OGX_PORT` matching `service.port`. Upgrade the chart or set the same on older manifests.
+
+2. **`ValueError: API 'safety' does not exist`** (or `agents`, `scoring`, etc.):
+   - OGX 1.x removed several Llama Stack-era APIs. This chart targets OGX 1.x (`responses`, `inference`, `vector_io`, `files`, `tool_runtime`, `batches`).
+   - Upgrade the chart and restart the deployment so `run-config` is regenerated.
+
+3. **`ValueError: Provider inline::rag-runtime is not available for API tool_runtime`**:
+   - The default image `ogxai/distribution-starter` does not include the RAG runtime provider.
+   - Chart defaults now set `toolRuntime.ragRuntime.enabled: false` and `toolGroups.rag.enabled: false`.
+   - Only enable those values if your OGX distribution includes `inline::rag-runtime`.
+
+4. **`ValidationError: ReferenceBatchesImplConfig sqlstore Field required`**:
+   - OGX 1.x batches provider config requires `sqlstore`, not the legacy `kvstore` block.
+   - Upgrade the chart so `run-config` uses `sqlstore.table_name: batches` with `backend: sql_default`.
+
+5. **Model Download Failures**:
    - Check internet connectivity
    - Verify HuggingFace access tokens
    - Ensure sufficient storage space
@@ -620,22 +620,22 @@ oc logs deployment/llama-stack -c llama-stack -f
    - Validate model configuration in LLM Service
 
 6. **Operator Mode Issues**:
-   - Verify llama-stack operator is installed: `kubectl get deployment -n llama-stack-operator-system`
+   - Verify ogx-ai operator is installed: `kubectl get deployment -n ogx-ai-operator-system`
    - Check if CRD is registered: `kubectl get crd llamastackdistributions.llamastack.io`
-   - Review operator logs for reconciliation errors: `kubectl logs -n llama-stack-operator-system -l app.kubernetes.io/name=llama-stack-operator`
+   - Review operator logs for reconciliation errors: `kubectl logs -n ogx-ai-operator-system -l app.kubernetes.io/name=ogx-ai-operator`
    - Check LlamaStackDistribution status and phase: `kubectl get llsd -o wide`
-   - View conditions for error details: `kubectl get llsd llama-stack -o jsonpath='{.status.conditions}' | jq`
+   - View conditions for error details: `kubectl get llsd ogx-ai -o jsonpath='{.status.conditions}' | jq`
    - Ensure operator has proper RBAC permissions
    - Verify the ConfigMap exists: `kubectl get configmap run-config`
    - Check for admission webhook errors in events: `kubectl get events --sort-by='.lastTimestamp'`
-   - Verify distribution image is accessible: `kubectl describe llsd llama-stack | grep -A5 distribution`
+   - Verify distribution image is accessible: `kubectl describe llsd ogx-ai | grep -A5 distribution`
 
 ### Resource Requirements
 
-LlamaStack is a lightweight orchestration layer and doesn't require GPU resources:
+OGX is a lightweight orchestration layer and doesn't require GPU resources:
 
 ```yaml
-# Typical LlamaStack resource requirements
+# Typical OGX resource requirements
 resources:
   requests:
     memory: "1Gi"
@@ -645,7 +645,7 @@ resources:
     cpu: "1000m"
 ```
 
-**Note**: Model inference resources are managed by the LLM Service component, not LlamaStack.
+**Note**: Model inference resources are managed by the LLM Service component, not OGX.
 
 ## Security and Authentication
 
@@ -682,26 +682,26 @@ The chart creates minimal RBAC permissions:
 
 ```bash
 # Upgrade with new image version
-helm upgrade llama-stack ./helm \
+helm upgrade ogx ./helm \
   --set image.tag=v0.3.0
 
 # Check rollout status
-oc rollout status deployment/llama-stack
+oc rollout status deployment/ogx
 ```
 
 ### Upgrading in Operator Mode
 
 ```bash
 # Upgrade the Helm release (updates the CRD)
-helm upgrade llama-stack ./helm \
+helm upgrade ogx-ai ./helm \
   --set managedByOperator=true \
   --set image.tag=v0.3.0
 
 # Watch the operator reconcile the changes
-kubectl get llamastackdistribution llama-stack -w
+kubectl get llamastackdistribution ogx-ai -w
 
 # Check operator-created deployment status
-oc rollout status deployment/llama-stack
+oc rollout status deployment/ogx-ai
 ```
 
 ### Switching Between Modes
@@ -714,10 +714,10 @@ oc rollout status deployment/llama-stack
 kubectl get crd llamastackdistributions.llama.meta.com
 
 # 2. Backup current configuration
-kubectl get deployment llama-stack -o yaml > llama-stack-backup.yaml
+kubectl get deployment ogx-ai -o yaml > ogx-ai-backup.yaml
 
 # 3. Upgrade to operator mode
-helm upgrade llama-stack ./helm \
+helm upgrade ogx-ai ./helm \
   --set managedByOperator=true \
   --reuse-values
 
@@ -729,10 +729,10 @@ helm upgrade llama-stack ./helm \
 **From Operator to Standard Mode:**
 ```bash
 # 1. Backup the CRD
-kubectl get llamastackdistribution llama-stack -o yaml > llama-stack-crd-backup.yaml
+kubectl get llamastackdistribution ogx-ai -o yaml > ogx-ai-crd-backup.yaml
 
 # 2. Upgrade to standard mode
-helm upgrade llama-stack ./helm \
+helm upgrade ogx-ai ./helm \
   --set managedByOperator=false \
   --reuse-values
 
@@ -745,10 +745,10 @@ helm upgrade llama-stack ./helm \
 
 ```bash
 # Remove chart
-helm uninstall llama-stack
+helm uninstall ogx
 
 # Remove persistent data
-oc delete pvc llama-stack-data
+oc delete pvc ogx-ai-data
 
 # Remove secrets (if needed)
 oc delete secret gcp-service-account
@@ -758,16 +758,16 @@ oc delete secret gcp-service-account
 
 This chart integrates with:
 
-- **LLM Service**: Deploy and serve models locally in the same namespace. LlamaStack automatically discovers and configures models deployed by the LLM Service chart
+- **LLM Service**: Deploy and serve models locally in the same namespace. OGX automatically discovers and configures models deployed by the LLM Service chart
 - **PGVector**: Vector database for embeddings and agent memory
 - **MinIO**: Model and data storage
 - **Ingestion Pipeline**: Document processing workflows
 - **VertexAI**: Google Cloud AI services
 - **MCP Servers**: External tool integration
 
-### LlamaStack + LLM Service Integration
+### OGX + LLM Service Integration
 
-LlamaStack works seamlessly with the LLM Service chart to provide a complete model serving solution:
+OGX works seamlessly with the LLM Service chart to provide a complete model serving solution:
 
 ```bash
 # 1. Deploy models using LLM Service
@@ -775,8 +775,8 @@ helm install llm-service ../llm-service/helm \
   --set models.llama-3-2-3b-instruct.enabled=true \
   --set models.llama-guard-3-8b.enabled=true
 
-# 2. Deploy LlamaStack and configure it to use the deployed models
-helm install llama-stack ./helm \
+# 2. Deploy OGX and configure it to use the deployed models
+helm install ogx ./helm \
   --set models.llama-3-2-3b-instruct.enabled=true \
   --set models.llama-guard-3-8b.enabled=true \
   --set models.llama-guard-3-8b.registerShield=true
@@ -784,43 +784,43 @@ helm install llama-stack ./helm \
 
 **How it works**:
 - LLM Service deploys models as InferenceServices with predictors
-- LlamaStack automatically generates URLs pointing to these predictors
+- OGX automatically generates URLs pointing to these predictors
 - Model URLs follow the pattern: `{model-name}-predictor.{namespace}.svc.cluster.local:8080/v1`
-- LlamaStack provides unified API access and orchestration layer
-- Safety shields and agent capabilities are handled by LlamaStack
+- OGX provides unified API access and orchestration layer
+- Safety shields and agent capabilities are handled by OGX
 - Model inference is handled by LLM Service/vLLM
 
 **Benefits of this approach**:
-- **Separation of concerns**: LLM Service handles model deployment, LlamaStack handles orchestration
+- **Separation of concerns**: LLM Service handles model deployment, OGX handles orchestration
 - **Automatic discovery**: No manual URL configuration needed for local models
 - **Unified API**: Single endpoint for multiple models and capabilities
 - **Safety integration**: Automatic shield model integration
-- **Agent capabilities**: Advanced AI agent features through LlamaStack
+- **Agent capabilities**: Advanced AI agent features through OGX
 
-### LlamaStack + PGVector Integration
+### OGX + PGVector Integration
 
-LlamaStack can be deployed with the PGVector component from this repository to provide persistent vector storage for embeddings, agent memory, and RAG capabilities:
+OGX can be deployed with the PGVector component from this repository to provide persistent vector storage for embeddings, agent memory, and RAG capabilities:
 
 ```bash
 # 1. Deploy PGVector using the pgvector chart from this repo
 helm install pgvector ../pgvector/helm \
-  --set secret.dbname=llamastack_vectors \
+  --set secret.dbname=ogx_vectors \
   --set extraDatabases[0].name=agent_memory \
   --set extraDatabases[0].vectordb=true
 
-# 2. Deploy LlamaStack configured to use the PGVector deployment
-helm install llama-stack ./helm \
+# 2. Deploy OGX configured to use the PGVector deployment
+helm install ogx ./helm \
   --set models.llama-3-2-3b-instruct.enabled=true
   # PGVector connection is automatically configured via environment variables
 ```
 
 **How it works**:
 - The PGVector chart from this repo creates a PostgreSQL deployment with pgvector extension
-- LlamaStack automatically connects using the `pgvector` secret created by the PGVector chart
+- OGX automatically connects using the `pgvector` secret created by the PGVector chart
 - Environment variables (`POSTGRES_USER`, `POSTGRES_PASSWORD`, etc.) are automatically configured
-- LlamaStack uses PGVector for vector storage, agent memory, and RAG operations
+- OGX uses PGVector for vector storage, agent memory, and RAG operations
 
-**What LlamaStack stores in PGVector**:
+**What OGX stores in PGVector**:
 - **Vector embeddings**: Document and text embeddings for RAG
 - **Agent memory**: Persistent memory for AI agents across sessions
 - **Knowledge base**: Long-term storage of facts and learned information
@@ -855,5 +855,5 @@ env:
   - name: OTEL_ENDPOINT
     value: "http://jaeger-collector:14268/api/traces"
   - name: OTEL_SERVICE_NAME
-    value: "llama-stack"
+    value: "ogx"
 ```

--- a/ogx-ai/helm/.helmignore
+++ b/ogx-ai/helm/.helmignore
@@ -1,0 +1,2 @@
+# Integration test umbrella chart — not part of the ogx-ai release package
+tests/

--- a/ogx-ai/helm/Chart.yaml
+++ b/ogx-ai/helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: ogx-ai
+description: Helm chart for OGX (formerly Llama Stack) — OpenAI-compatible agentic API server
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.8.6
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.8.6"

--- a/ogx-ai/helm/templates/_helpers.tpl
+++ b/ogx-ai/helm/templates/_helpers.tpl
@@ -1,0 +1,99 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ogx-ai.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ogx-ai.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ogx-ai.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ogx-ai.labels" -}}
+helm.sh/chart: {{ include "ogx-ai.chart" . }}
+{{ include "ogx-ai.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ogx-ai.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ogx-ai.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ogx-ai.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ogx-ai.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "ogx-ai.mergeModels" -}}
+  {{- $root := . }}
+  {{- $globalModels := .Values.global | default dict }}
+  {{- $globalModels := $globalModels.models | default dict }}
+  {{- $localModels := .Values.models | default dict }}
+  {{- $merged := merge $globalModels $localModels }}
+  {{- range $key, $model := $merged }}
+    {{- if not $model.url }}
+      {{- $url := printf "https://%s.%s.svc.cluster.local/v1" $key $root.Release.Namespace }}
+      {{- if $root.Values.rawDeploymentMode }}
+        {{- $url = printf "http://%s-vllm.%s.svc.cluster.local/v1" $key $root.Release.Namespace }}
+      {{- end }}
+      {{- $_ := set $merged $key (merge $model (dict "url" $url)) }}
+    {{- end }}
+  {{- end }}
+  {{- toJson $merged }}
+{{- end }}
+
+{{- define "ogx-ai.mergeMcpServers" -}}
+  {{- $globalServers := .Values.global | default dict }}
+  {{- $globalServers := index $globalServers "mcp-servers" | default dict }}
+  {{- $localServers := index .Values "mcp-servers" | default dict }}
+  {{- $merged := merge $globalServers $localServers }}
+  {{- toJson $merged }}
+{{- end }}
+
+{{- define "ogx-ai.hasEnabledModels" -}}
+  {{- $found := false }}
+  {{- $models := include "ogx-ai.mergeModels" . | fromJson }}
+  {{- range $key, $model := $models }}
+    {{- if and $model.enabled (ne $key "remote-llm") }}
+      {{- $found = true }}
+    {{- end }}
+  {{- end }}
+  {{- if $found }}true{{- end }}
+{{- end }}

--- a/ogx-ai/helm/templates/configmap.yaml
+++ b/ogx-ai/helm/templates/configmap.yaml
@@ -1,0 +1,198 @@
+{{- $models := include "ogx-ai.mergeModels" . | fromJson }}
+{{- $mcpServers := include "ogx-ai.mergeMcpServers" . | fromJson }}
+{{- $hasToolRuntime := or .Values.toolRuntime.braveSearch.enabled .Values.toolRuntime.tavilySearch.enabled .Values.toolRuntime.ragRuntime.enabled .Values.toolRuntime.modelContextProtocol.enabled }}
+{{- $hasToolGroups := or .Values.toolGroups.websearch.enabled (and .Values.toolGroups.rag.enabled .Values.toolRuntime.ragRuntime.enabled) (gt (len $mcpServers) 0) }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: run-config
+data:
+  config.yaml: |
+    version: 2
+    image_name: starter
+    apis:
+      - batches
+      - files
+      - inference
+      - responses
+      - tool_runtime
+      - vector_io
+    providers:
+      inference:
+      {{- range $key, $model := $models }}
+      {{- if $model.enabled }}
+      - provider_id: {{ $key }}
+        provider_type: remote::vllm
+        config:
+          base_url: {{ $model.url }}
+          api_token: {{ $model.apiToken | default "fake" }}
+          max_tokens: {{ $model.maxTokens | default 4096 }}
+          tls_verify: {{ $model.tlsVerify | default false }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.vertexai.enabled }}
+      - provider_id: {{ .Values.vertexai.projectId }}-vertexai
+        provider_type: remote::vertexai
+        config:
+          project: {{ .Values.vertexai.projectId }}
+          location: {{ .Values.vertexai.location }}
+      {{- end }}
+      - provider_id: sentence-transformers
+        provider_type: inline::sentence-transformers
+      {{- if .Values.pgvector.enabled }}
+      vector_io:
+      - provider_id: pgvector
+        provider_type: remote::pgvector
+        config:
+          host: ${env.POSTGRES_HOST:=pgvector}
+          port: ${env.POSTGRES_PORT:=5432}
+          db: ${env.POSTGRES_DBNAME:=rag_blueprint}
+          user: ${env.POSTGRES_USER:=postgres}
+          password: ${env.POSTGRES_PASSWORD:=rag_password}
+          persistence:
+            {{- toYaml .Values.vectorIOKvstore | nindent 12 }}
+      {{- end }}
+      files:
+      - provider_id: meta-reference-files
+        provider_type: inline::localfs
+        config:
+          storage_dir: ${env.FILES_STORAGE_DIR:=~/.llama/distributions/starter/files}
+          metadata_store:
+            table_name: files_metadata
+            backend: sql_default
+      responses:
+      {{- with .Values.providers.responses }}
+      {{- toYaml . | nindent 6 }}
+      {{- else }}
+      - provider_id: builtin
+        provider_type: inline::builtin
+        config:
+          moderation_endpoint: ${env.MODERATION_ENDPOINT:+}
+          persistence:
+            agent_state:
+              namespace: agents
+              backend: kv_default
+            responses:
+              table_name: responses
+              backend: sql_default
+              max_write_queue_size: 10000
+              num_writers: 4
+      {{- end }}
+      {{- if not $hasToolRuntime }}
+      # OGX StackConfig requires a list; bare "tool_runtime:" parses as null in YAML
+      tool_runtime: []
+      {{- else }}
+      tool_runtime:
+      {{- if .Values.toolRuntime.braveSearch.enabled }}
+      - provider_id: brave-search
+        provider_type: remote::brave-search
+        config:
+          api_key: ${env.BRAVE_SEARCH_API_KEY:=}
+          max_results: 3
+      {{- end }}
+      {{- if .Values.toolRuntime.tavilySearch.enabled }}
+      - provider_id: tavily-search
+        provider_type: remote::tavily-search
+        config:
+          api_key: ${env.TAVILY_SEARCH_API_KEY:=}
+          max_results: 3
+      {{- end }}
+      {{- if .Values.toolRuntime.ragRuntime.enabled }}
+      - provider_id: rag-runtime
+        provider_type: inline::rag-runtime
+      {{- end }}
+      {{- if .Values.toolRuntime.modelContextProtocol.enabled }}
+      - provider_id: model-context-protocol
+        provider_type: remote::model-context-protocol
+      {{- end }}
+      {{- end }}
+      batches:
+      - provider_id: reference
+        provider_type: inline::reference
+        config:
+          sqlstore:
+            table_name: batches
+            backend: sql_default
+    storage:
+      backends:
+        {{- if and .Values.storage .Values.storage.backends }}
+        {{- toYaml .Values.storage.backends | nindent 8 }}
+        {{- else }}
+        kv_default:
+          type: kv_sqlite
+          db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter}/kvstore.db
+        sql_default:
+          type: sql_sqlite
+          db_path: ${env.SQLITE_STORE_DIR:=~/.llama/distributions/starter}/sql_store.db
+        {{- end }}
+      stores:
+        metadata:
+          namespace: registry
+          backend: kv_default
+        inference:
+          table_name: inference_store
+          backend: sql_default
+          max_write_queue_size: 10000
+          num_writers: 4
+        conversations:
+          table_name: openai_conversations
+          backend: sql_default
+    registered_resources:
+      {{- if include "ogx-ai.hasEnabledModels" . }}
+      models:
+      {{- range $key, $model := $models }}
+      {{- if and $model.enabled (ne $key "remote-llm") }}
+      - metadata: {}
+        model_id: {{ $model.id }}
+        provider_id: {{ $key }}
+        model_type: llm
+      {{- end }}
+      {{- end }}
+      {{- else }}
+      models: []
+      {{- end }}
+      vector_dbs: []
+      datasets: []
+      scoring_fns: []
+      benchmarks: []
+      {{- if not $hasToolGroups }}
+      # OGX StackConfig requires a list; bare "tool_groups:" parses as null in YAML
+      tool_groups: []
+      {{- else }}
+      tool_groups:
+      {{- if .Values.toolGroups.websearch.enabled }}
+      - toolgroup_id: builtin::websearch
+        provider_id: tavily-search
+      {{- end }}
+      {{- if and .Values.toolGroups.rag.enabled .Values.toolRuntime.ragRuntime.enabled }}
+      - toolgroup_id: builtin::rag
+        provider_id: rag-runtime
+      {{- end }}
+      {{- range $key, $server := $mcpServers }}
+      - toolgroup_id: mcp::{{ $key }}
+        provider_id: model-context-protocol
+        mcp_endpoint:
+          uri: {{ $server.uri }}
+      {{- end }}
+      {{- end }}
+    server:
+      port: 8321
+      {{- if .Values.auth }}
+      auth:
+        {{- with .Values.auth.provider_config }}
+        provider_config:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.auth.access_policy }}
+        access_policy:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
+    telemetry:
+      enabled: true
+    vector_stores:
+      default_provider_id: pgvector
+      default_embedding_model:
+        provider_id: sentence-transformers
+        model_id: nomic-ai/nomic-embed-text-v1.5

--- a/ogx-ai/helm/templates/deployment.yaml
+++ b/ogx-ai/helm/templates/deployment.yaml
@@ -1,0 +1,184 @@
+{{- $models := include "ogx-ai.mergeModels" . | fromJson }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ogx-ai.fullname" . }}
+  labels:
+    {{- include "ogx-ai.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ogx-ai.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ogx-ai.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ogx-ai.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if include "ogx-ai.hasEnabledModels" . }}
+      initContainers:
+        - name: wait-for-models
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          envFrom:
+          - secretRef:
+              name: {{ .Chart.Name }}-env
+          {{- with .Values.extraSecretRefs }}
+          {{- range . }}
+          - secretRef:
+              name: {{ .name | default . }}
+          {{- end }}
+          {{- end }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -e
+              # Function to resolve ${env.VAR} syntax to actual env var values
+              resolve_env_var() {
+                local val="$1"
+                if [[ "$val" =~ ^\$\{env\.([^}]+)\}$ ]]; then
+                  echo "${!BASH_REMATCH[1]}"
+                else
+                  echo "$val"
+                fi
+              }
+              for url_data in {{ range $key, $model := $models }}{{- if $model.enabled }}{{ $model.url }}/models#{{ $model.apiToken }} {{ end }}{{ end }}; do
+                url_components=(${url_data//#/ })
+                url=${url_components[0]}
+                auth=$(resolve_env_var "${url_components[1]}")
+                echo "Waiting for $url..."
+                curl_options=("-ksf" "$url")
+                if [[ -n "$auth" ]]; then
+                  curl_options+=("-H" "Authorization: Bearer $auth")
+                fi
+                until curl "${curl_options[@]}"; do
+                  echo "Still waiting for $url ..."
+                  sleep 10
+                done
+                echo "$url is ready."
+              done
+              echo "All services are up."
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+            - name: OGX_PORT
+              value: {{ .Values.service.port | quote }}
+            {{- if .Values.otelExporter }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.otelExporter }}
+            {{- end }}
+            {{- if .Values.telemetrySinks }}
+            - name: TELEMETRY_SINKS
+              value: {{ .Values.telemetrySinks }}
+            {{- end }}
+            {{- if .Values.pgvector.enabled }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  key: user
+                  name: pgvector
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: pgvector
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: host
+                  name: pgvector
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  key: port
+                  name: pgvector
+            - name: POSTGRES_DBNAME
+              valueFrom:
+                secretKeyRef:
+                  key: dbname
+                  name: pgvector
+            {{- end }}
+          envFrom:
+          - secretRef:
+              name: {{ .Chart.Name }}-env
+          {{- with .Values.extraSecretRefs }}
+          {{- range . }}
+          - secretRef:
+              name: {{ .name | default . }}
+          {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- if .Values.gcpServiceAccountFile }}
+            - name: {{ .Values.gcpServiceAccount.name }}
+              mountPath: {{ .Values.gcpServiceAccount.mountPath }}
+              subPath: gcp-service-account.json
+            {{- end }}
+      volumes:
+        {{- toYaml .Values.volumes | nindent 8 }}
+        {{- if .Values.gcpServiceAccountFile }}
+        - name: {{ .Values.gcpServiceAccount.name }}
+          secret:
+            secretName: {{ .Values.gcpServiceAccount.name }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/ogx-ai/helm/templates/pvc.yaml
+++ b/ogx-ai/helm/templates/pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: ogx-ai-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  volumeMode: Filesystem

--- a/ogx-ai/helm/templates/route.yaml
+++ b/ogx-ai/helm/templates/route.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.route.enabled }}
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ .Values.route.name }}
+  labels:
+    {{- include "ogx-ai.labels" . | nindent 4 }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  to:
+    kind: Service
+    name: {{ include "ogx-ai.fullname" . }}
+    weight: 100
+  port:
+    targetPort: http
+  wildcardPolicy: None
+  {{- with .Values.route.host }}
+  host: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.route.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/ogx-ai/helm/templates/secret.yaml
+++ b/ogx-ai/helm/templates/secret.yaml
@@ -1,0 +1,24 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}-env
+type: Opaque
+data:
+  {{- range $key, $value:= .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.gcpServiceAccountFile }}
+  GOOGLE_APPLICATION_CREDENTIALS: {{ .Values.gcpServiceAccount.mountPath | b64enc | quote }}
+  {{- end }}
+
+---
+{{- if .Values.gcpServiceAccountFile }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.gcpServiceAccount.name }}
+type: Opaque
+data:
+  gcp-service-account.json: {{ .Values.gcpServiceAccountFile | b64enc | quote }}
+{{- end }}

--- a/ogx-ai/helm/templates/service.yaml
+++ b/ogx-ai/helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ogx-ai.fullname" . }}
+  labels:
+    {{- include "ogx-ai.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ogx-ai.selectorLabels" . | nindent 4 }}

--- a/ogx-ai/helm/values.yaml
+++ b/ogx-ai/helm/values.yaml
@@ -6,9 +6,9 @@ replicaCount: 1
 rawDeploymentMode: true
 
 image:
-  repository: ogxai/distribution-starter
+  repository: quay.io/opendatahub/odh-ogx-core
   pullPolicy: IfNotPresent
-  tag: "1.0.2"
+  tag: "rhoai-v3.5-ea1-latest"
 
 imagePullSecrets: []
 nameOverride: "ogx-ai"

--- a/ogx-ai/helm/values.yaml
+++ b/ogx-ai/helm/values.yaml
@@ -1,0 +1,265 @@
+# Default values for OGX (https://github.com/ogx-ai/ogx).
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+rawDeploymentMode: true
+
+image:
+  repository: ogxai/distribution-starter
+  pullPolicy: IfNotPresent
+  tag: "1.0.2"
+
+imagePullSecrets: []
+nameOverride: "ogx-ai"
+fullnameOverride: "ogx-ai"
+
+serviceAccount:
+  create: false
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+progressDeadlineSeconds: 3600
+
+strategy:
+  type: Recreate
+
+service:
+  type: ClusterIP
+  port: 8321
+
+# OpenShift Route for external access. Defaults to name "llamastack" for backwards
+# compatibility with charts and jobs that still reference the Llama Stack service name.
+route:
+  enabled: true
+  name: ogx-ai
+  host: ""
+  annotations: {}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+
+# Disable automatic service env vars (e.g. OGX_PORT=tcp://...) which collide with the
+# OGX CLI's numeric OGX_PORT when the Service is named "ogx".
+enableServiceLinks: false
+
+env:
+  - name: RUN_CONFIG_PATH
+    value: /app-config/config.yaml
+
+# PGVector configuration - set enabled to true to enable pgvector integration
+pgvector:
+  enabled: true # backwards compatibility
+  # When enabled, the following environment variables will be automatically added
+  # from the 'pgvector' secret in the deployment.yaml
+  # - POSTGRES_USER
+  # - POSTGRES_PASSWORD
+  # - POSTGRES_HOST
+  # - POSTGRES_PORT
+  # - POSTGRES_DBNAME
+
+resources: {}
+
+livenessProbe:
+  httpGet:
+    path: /v1/health
+    port: 8321
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /v1/health
+    port: 8321
+  initialDelaySeconds: 15
+  periodSeconds: 15
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+autoscaling:
+  enabled: false
+
+# Additional volumes on the output Deployment definition.
+volumes:
+  - configMap:
+      defaultMode: 420
+      name: run-config
+    name: run-config-volume
+  - name: dot-ogx-ai
+    persistentVolumeClaim:
+      claimName: ogx-ai-data
+  - emptyDir: {}
+    name: cache
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts:
+  - mountPath: /app-config
+    name: run-config-volume
+  - mountPath: /.llama
+    name: dot-ogx-ai
+  - mountPath: /.cache
+    name: cache
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+gcpServiceAccount:
+  name: gcp-service-account
+  mountPath: /var/secrets/gcp-service-account.json
+
+vertexai:
+  enabled: false
+  #projectId:
+  #location:
+
+secrets: {}
+
+# Extra secret references to mount as environment variables in init and main containers
+# Example: extraSecretRefs: [{ name: my-api-keys-secret }]
+extraSecretRefs: []
+
+mcp-servers: {}
+models:
+  gpt-oss-20b:
+    id: openai/gpt-oss-20b
+    enabled: false
+  llama-3-2-3b-instruct:
+    id: meta-llama/Llama-3.2-3B-Instruct
+    enabled: false
+  llama-guard-3-8b:
+    id: meta-llama/Llama-Guard-3-8B
+    enabled: false
+    registerShield: true
+  llama-3-2-1b-instruct:
+    id: meta-llama/Llama-3.2-1B-Instruct
+    enabled: false
+  llama-3-1-8b-instruct:
+    id: meta-llama/Llama-3.1-8B-Instruct
+    enabled: false
+  llama-guard-3-1b:
+    id: meta-llama/Llama-Guard-3-1B
+    enabled: false
+    registerShield: true
+  llama-3-3-70b-instruct:
+    id: meta-llama/Llama-3.3-70B-Instruct
+    enabled: false
+  llama-3-2-1b-instruct-quantized:
+    id: RedHatAI/Llama-3.2-1B-Instruct-quantized.w8a8
+    enabled: false
+  # To configure OGX with remote llm provider (without registering a specific model),
+  # set url and optionally apiToken, then set enabled to true
+  remote-llm:
+    url: ""
+    apiToken: ""
+    enabled: false
+
+# Vector IO provider persistence configuration
+# By default uses kv_default backend defined in storage section
+# For multi-replica deployments, override in parent values.yaml to use PostgreSQL
+vectorIOKvstore:
+  namespace: vector_io::pgvector
+  backend: kv_default
+
+# Optional: Override storage backends (defaults to SQLite if not provided)
+# storage:
+#   backends:
+#     kv_default:
+#       type: kv_postgres
+#       host: pgvector
+#       port: 5432
+#       db: llama_agents
+#       user: postgres
+#       password: rag_password
+#     sql_default:
+#       type: sql_postgres
+#       host: pgvector
+#       port: 5432
+#       db: llama_responses
+#       user: postgres
+#       password: rag_password
+
+# OGX 1.x: agents/safety/shields APIs removed; use responses + optional MODERATION_ENDPOINT
+providers:
+  responses:
+    - provider_id: builtin
+      provider_type: inline::builtin
+      config:
+        moderation_endpoint: ${env.MODERATION_ENDPOINT:+}
+        persistence:
+          agent_state:
+            namespace: agents
+            backend: kv_default
+          responses:
+            table_name: responses
+            backend: sql_default
+            max_write_queue_size: 10000
+            num_writers: 4
+
+auth: {}
+
+# Tool runtime providers included in run-config. The distribution-starter image
+# (ogxai/distribution-starter) does not ship inline::rag-runtime; leave disabled
+# unless you use a distribution that includes it.
+toolRuntime:
+  braveSearch:
+    enabled: true
+  tavilySearch:
+    enabled: true
+  ragRuntime:
+    enabled: false
+  modelContextProtocol:
+    enabled: true
+
+toolGroups:
+  websearch:
+    enabled: true
+  rag:
+    enabled: false
+# auth:
+#   provider_config:
+#     type: "custom"
+#     endpoint: "https://auth.example.com/validate"
+#   access_policy:
+#   - permit:
+#       actions: [create]
+#       resource: session::*
+#     description: all users have create access to sessions
+#   - permit:
+#       actions: [read]
+#       resource: agent::*
+#     description: all users have read access to agents
+#   - permit:
+#       actions: [read]
+#       resource: tool_group::*
+#     description: all users have read access to tool_groups
+#   - permit:
+#       actions: [read]
+#       resource: model::*
+#     description: all users have read access to models
+#   - permit:
+#       actions: [read]
+#       resource: vector_db::*
+#     description: all users have read access to vector_dbs
+#   - permit:
+#       actions: [create, update, delete]
+#       resource: vector_db::*
+#     when: user with admin in roles
+#     description: users with the admin role can create, update or delete vector_dbs
+#   - forbid:
+#       actions: [create, update, delete]
+#     unless: user with admin in roles
+#     description: only users with the admin role can create, update or delete resources
+#   - permit:
+#       actions: [read, update, delete]
+#     when: user is owner
+#     description: users can read, update and delete resources they own

--- a/ogx-ai/tests/Chart.lock
+++ b/ogx-ai/tests/Chart.lock
@@ -1,0 +1,18 @@
+dependencies:
+- name: llm-service
+  repository: file://../../llm-service/helm
+  version: 0.5.9
+- name: ogx-ai
+  repository: file://../helm
+  version: 0.8.6
+- name: pgvector
+  repository: file://../../pgvector/helm
+  version: 0.5.5
+- name: configure-pipeline
+  repository: file://../../configure-pipeline/helm
+  version: 0.5.8
+- name: ingestion-pipeline
+  repository: file://../../ingestion-pipeline/helm
+  version: 0.7.4
+digest: sha256:cfdd73af680280863f806a0e83ed6b7b450195aa1403a638946648069f63f4ed
+generated: "2026-06-11T10:16:44.535058-04:00"

--- a/ogx-ai/tests/Chart.yaml
+++ b/ogx-ai/tests/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: ogx-ai-test
+description: Integration test chart deploying ogx-ai with llm-service and optional ingestion pipeline
+
+type: application
+
+version: 0.1.0
+appVersion: "1.0.2"
+
+dependencies:
+  - name: llm-service
+    version: "0.5.9"
+    repository: "file://../../llm-service/helm"
+  - name: ogx-ai
+    version: "0.8.6"
+    repository: "file://../helm"
+  - name: pgvector
+    version: "0.5.5"
+    repository: "file://../../pgvector/helm"
+    condition: pgvector.enabled
+  - name: configure-pipeline
+    version: "0.5.8"
+    repository: "file://../../configure-pipeline/helm"
+    condition: configure-pipeline.enabled
+  - name: ingestion-pipeline
+    version: "0.7.4"
+    repository: "file://../../ingestion-pipeline/helm"
+    condition: ingestion-pipeline.enabled

--- a/ogx-ai/tests/Makefile
+++ b/ogx-ai/tests/Makefile
@@ -1,0 +1,43 @@
+# Install and uninstall the ogx-ai integration test umbrella chart.
+#
+# Usage:
+#   export HF_TOKEN=...
+#   make install
+#   make uninstall
+#
+# Optional overrides:
+#   NAMESPACE=my-ns HF_TOKEN=... make install
+#   DEVICE=gpu HF_TOKEN=... make install
+#   HELM_EXTRA_ARGS='--set ingestion-pipeline.enabled=false' HF_TOKEN=... make install
+
+RELEASE_NAME ?= ogx-ai-test
+CHART_DIR      := .
+VALUES_FILE    := values.yaml
+DEVICE         ?= cpu
+KUBECTL        ?= oc
+HELM           ?= helm
+
+ifneq ($(NAMESPACE),)
+HELM_NS_ARGS   := --namespace $(NAMESPACE)
+KUBECTL_NS_ARGS := -n $(NAMESPACE)
+endif
+
+.PHONY: install uninstall deps
+
+deps:
+	$(HELM) dependency update $(CHART_DIR)
+
+install: deps
+ifndef HF_TOKEN
+	$(error HF_TOKEN is required — export it or pass HF_TOKEN=... on the command line)
+endif
+	$(HELM) upgrade --install $(RELEASE_NAME) $(CHART_DIR) \
+		-f $(VALUES_FILE) \
+		$(HELM_NS_ARGS) \
+		--set llm-service.device=$(DEVICE) \
+		--set llm-service.secret.hf_token="$(HF_TOKEN)" \
+		$(HELM_EXTRA_ARGS)
+
+uninstall:
+	-$(HELM) uninstall $(RELEASE_NAME) $(HELM_NS_ARGS)
+	$(KUBECTL) delete pvc ogx-ai-data pgvector-pg-data $(KUBECTL_NS_ARGS) --ignore-not-found

--- a/ogx-ai/tests/README.md
+++ b/ogx-ai/tests/README.md
@@ -1,0 +1,106 @@
+# OGX AI integration test chart
+
+Umbrella chart that deploys **ogx-ai**, **llm-service**, and an optional **ingestion pipeline** smoke test (similar to the RAG blueprint, but trimmed down).
+
+## What it deploys
+
+| Component | Purpose |
+|-----------|---------|
+| `llm-service` | Serves `meta-llama/Llama-3.2-1B-Instruct` via vLLM |
+| `ogx-ai` | OpenAI-compatible API (service name `llamastack` for pipeline compatibility) |
+| `pgvector` | Vector store backend for OGX `vector_io` |
+| `configure-pipeline` | OpenShift Data Science Pipelines + MinIO for KFP artifacts |
+| `ingestion-pipeline` | One GitHub-sourced pipeline that ingests `docs/` from the RAG repo |
+
+External search tools are disabled to keep the footprint small.
+
+Model enablement is configured separately under `llm-service.models` and `ogx-ai.models` (not `global.models`), because ogx-ai injects predictor URLs into the shared global model map and would prevent llm-service from creating InferenceServices.
+
+## Prerequisites
+
+- OpenShift cluster with **OpenShift AI** and **Data Science Pipelines** (DSP)
+- Helm 3.x
+- HuggingFace token with access to [Llama 3.2 1B Instruct](https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct)
+- CPU nodes (default) or GPU nodes when overriding `llm-service.device`
+
+## Install
+
+From the `ogx-ai` chart directory:
+
+```bash
+helm dependency update ./tests
+
+helm install ogx-ai-test ./tests \
+  --set llm-service.secret.hf_token="$HF_TOKEN"
+```
+
+### GPU install
+
+```bash
+helm install ogx-ai-test ./tests \
+  --set llm-service.device=gpu \
+  --set llm-service.secret.hf_token="$HF_TOKEN"
+```
+
+### OGX + llm-service only (no ingestion)
+
+```bash
+helm install ogx-ai-test ./tests \
+  --set ingestion-pipeline.enabled=false \
+  --set configure-pipeline.enabled=false \
+  --set pgvector.enabled=false \
+  --set ogx-ai.pgvector.enabled=false \
+  --set llm-service.secret.hf_token="$HF_TOKEN"
+```
+
+## Verify
+
+Wait for pods and the llm-service InferenceService to become ready:
+
+```bash
+kubectl get inferenceservices
+kubectl get pods
+kubectl get datasciencepipelinesapplications
+```
+
+Check OGX health (service is named `llamastack`):
+
+```bash
+kubectl port-forward svc/llamastack 8321:8321
+
+curl -s http://localhost:8321/v1/health
+curl -s http://localhost:8321/v1/models
+```
+
+Check the ingestion pipeline API:
+
+```bash
+kubectl port-forward svc/ingestion-pipeline 8080:80
+
+curl -s http://localhost:8080/ping
+```
+
+After the bootstrap Jobs finish, confirm a Kubeflow pipeline run was created (OpenShift AI dashboard → Pipelines, or):
+
+```bash
+kubectl get pipelineruns
+```
+
+Send a chat completion:
+
+```bash
+curl -s http://localhost:8321/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-llama/Llama-3.2-1B-Instruct",
+    "messages": [{"role": "user", "content": "Say hello in one sentence."}],
+    "max_tokens": 64
+  }'
+```
+
+## Uninstall
+
+```bash
+helm uninstall ogx-ai-test
+kubectl delete pvc ogx-ai-data pgvector-pg-data --ignore-not-found
+```

--- a/ogx-ai/tests/README.md
+++ b/ogx-ai/tests/README.md
@@ -2,15 +2,61 @@
 
 Umbrella chart that deploys **ogx-ai**, **llm-service**, and an optional **ingestion pipeline** smoke test (similar to the RAG blueprint, but trimmed down).
 
+Use this chart to validate that the OGX stack works end-to-end on a live OpenShift AI cluster before promoting chart or values changes.
+
+## What is tested
+
+This is a **manual integration smoke test**, not an automated CI suite. A successful install and verify run confirms the following:
+
+### Chart and platform integration
+
+| Area | What is validated |
+|------|-------------------|
+| Umbrella chart wiring | Subcharts (`ogx-ai`, `llm-service`, `pgvector`, `configure-pipeline`, `ingestion-pipeline`) resolve, install, and start together from a single release |
+| OpenShift AI / DSP | Data Science Pipelines Application (`ds-pipeline-dspa`) becomes healthy and is reachable from the ingestion-pipeline init container |
+| `clientDependency: ogx-ai` | Ingestion-pipeline waits for and talks to the `ogx-ai` service (not legacy `llamastack`) |
+
+### Inference and API
+
+| Area | What is validated |
+|------|-------------------|
+| `llm-service` | Deploys `meta-llama/Llama-3.2-1B-Instruct` via vLLM (CPU by default; GPU via `DEVICE=gpu`) |
+| Model routing | `ogx-ai` discovers the in-namespace llm-service predictor and exposes the model on `/v1/models` |
+| OpenAI-compatible API | OGX `/v1/health`, `/v1/models`, and `/v1/chat/completions` respond successfully |
+| Embeddings | Default OGX embedding model (`nomic-embed-text-v1.5`) is listed and available for RAG tasks |
+
+### RAG stack (default install)
+
+| Area | What is validated |
+|------|-------------------|
+| `pgvector` | Vector store deploys and is configured as OGX `vector_io` backend |
+| `configure-pipeline` | DSP workspace, pipeline storage, and embedded MinIO for KFP artifacts come up (notebook is disabled) |
+| `ingestion-pipeline` API | Service `/ping` responds after init containers pass |
+| Bootstrap job | `add-smoke-github-pipeline` Job registers the `smoke-github` pipeline via the ingestion API |
+| GitHub ingestion | Kubeflow `PipelineRun` is created for pipeline `smoke-github`, ingesting public `docs/` from [rh-ai-quickstart/RAG](https://github.com/rh-ai-quickstart/RAG) into vector store `ogx-test-kb-v1-0` using `all-MiniLM-L6-v2` embeddings |
+
+### Explicitly out of scope
+
+The test values intentionally disable features that add cost, secrets, or external dependencies:
+
+- External web search (Brave, Tavily)
+- MCP tool runtime
+- DSP notebook server
+- MinIO document bucket (GitHub source only — no S3 document upload path)
+- Operator-based OGX deployment (`managedByOperator`)
+- Automated test assertions or teardown hooks
+
+To test only OGX + inference without RAG, disable the ingestion-related subcharts (see [OGX + llm-service only](#ogx--llm-service-only-no-ingestion) below).
+
 ## What it deploys
 
 | Component | Purpose |
 |-----------|---------|
 | `llm-service` | Serves `meta-llama/Llama-3.2-1B-Instruct` via vLLM |
-| `ogx-ai` | OpenAI-compatible API (service name `llamastack` for pipeline compatibility) |
+| `ogx-ai` | OpenAI-compatible API (`ogx-ai` service; `ingestion-pipeline.clientDependency: ogx-ai`) |
 | `pgvector` | Vector store backend for OGX `vector_io` |
 | `configure-pipeline` | OpenShift Data Science Pipelines + MinIO for KFP artifacts |
-| `ingestion-pipeline` | One GitHub-sourced pipeline that ingests `docs/` from the RAG repo |
+| `ingestion-pipeline` | Registers and runs one GitHub-sourced smoke pipeline |
 
 External search tools are disabled to keep the footprint small.
 
@@ -25,7 +71,14 @@ Model enablement is configured separately under `llm-service.models` and `ogx-ai
 
 ## Install
 
-From the `ogx-ai` chart directory:
+From the `ogx-ai/tests` directory:
+
+```bash
+export HF_TOKEN=...
+make install
+```
+
+Or with Helm directly:
 
 ```bash
 helm dependency update ./tests
@@ -34,23 +87,22 @@ helm install ogx-ai-test ./tests \
   --set llm-service.secret.hf_token="$HF_TOKEN"
 ```
 
+Optional Makefile variables: `NAMESPACE`, `DEVICE` (`cpu` or `gpu`), `RELEASE_NAME`, `HELM_EXTRA_ARGS`.
+
 ### GPU install
 
 ```bash
-helm install ogx-ai-test ./tests \
-  --set llm-service.device=gpu \
-  --set llm-service.secret.hf_token="$HF_TOKEN"
+DEVICE=gpu HF_TOKEN=... make install
 ```
 
 ### OGX + llm-service only (no ingestion)
 
 ```bash
-helm install ogx-ai-test ./tests \
+HF_TOKEN=... make install HELM_EXTRA_ARGS='\
   --set ingestion-pipeline.enabled=false \
   --set configure-pipeline.enabled=false \
   --set pgvector.enabled=false \
-  --set ogx-ai.pgvector.enabled=false \
-  --set llm-service.secret.hf_token="$HF_TOKEN"
+  --set ogx-ai.pgvector.enabled=false'
 ```
 
 ## Verify
@@ -58,24 +110,24 @@ helm install ogx-ai-test ./tests \
 Wait for pods and the llm-service InferenceService to become ready:
 
 ```bash
-kubectl get inferenceservices
-kubectl get pods
-kubectl get datasciencepipelinesapplications
+oc get inferenceservices
+oc get pods
+oc get datasciencepipelinesapplications
 ```
 
-Check OGX health (service is named `llamastack`):
+Check OGX health:
 
 ```bash
-kubectl port-forward svc/llamastack 8321:8321
+oc port-forward svc/ogx-ai 8321:8321
 
 curl -s http://localhost:8321/v1/health
 curl -s http://localhost:8321/v1/models
 ```
 
-Check the ingestion pipeline API:
+Check the ingestion pipeline API (service name includes the release prefix):
 
 ```bash
-kubectl port-forward svc/ingestion-pipeline 8080:80
+oc port-forward svc/ogx-ai-test-ingestion-pipeline 8080:80
 
 curl -s http://localhost:8080/ping
 ```
@@ -83,7 +135,8 @@ curl -s http://localhost:8080/ping
 After the bootstrap Jobs finish, confirm a Kubeflow pipeline run was created (OpenShift AI dashboard → Pipelines, or):
 
 ```bash
-kubectl get pipelineruns
+oc get jobs -l app.kubernetes.io/name=ingestion-pipeline
+oc get pipelineruns
 ```
 
 Send a chat completion:
@@ -101,6 +154,12 @@ curl -s http://localhost:8321/v1/chat/completions \
 ## Uninstall
 
 ```bash
+make uninstall
+```
+
+Or:
+
+```bash
 helm uninstall ogx-ai-test
-kubectl delete pvc ogx-ai-data pgvector-pg-data --ignore-not-found
+oc delete pvc ogx-ai-data pgvector-pg-data --ignore-not-found
 ```

--- a/ogx-ai/tests/values.yaml
+++ b/ogx-ai/tests/values.yaml
@@ -81,6 +81,7 @@ configure-pipeline:
 
 ingestion-pipeline:
   enabled: true
+  clientDependency: ogx-ai
   serviceAccount:
     create: true
     name: ogx-test-pipeline

--- a/ogx-ai/tests/values.yaml
+++ b/ogx-ai/tests/values.yaml
@@ -1,0 +1,101 @@
+# Integration test values for ogx-ai + llm-service (+ optional ingestion pipeline).
+# Uses Llama 3.2 1B Instruct — the smallest bundled model — on CPU by default.
+#
+# Note: do not use global.models here. ogx-ai mergeModels injects predictor URLs
+# into the shared global map, which makes llm-service skip InferenceService creation.
+#
+# Install:
+#   helm dependency update ./tests
+#   helm install ogx-ai-test ./tests \
+#     --set llm-service.secret.hf_token="$HF_TOKEN"
+#
+# GPU clusters can override device:
+#   helm install ogx-ai-test ./tests \
+#     --set llm-service.device=gpu \
+#     --set llm-service.secret.hf_token="$HF_TOKEN"
+#
+# Disable ingestion (ogx-ai + llm-service only):
+#   helm install ogx-ai-test ./tests \
+#     --set ingestion-pipeline.enabled=false \
+#     --set configure-pipeline.enabled=false \
+#     --set pgvector.enabled=false \
+#     --set ogx-ai.pgvector.enabled=false \
+#     --set llm-service.secret.hf_token="$HF_TOKEN"
+
+llm-service:
+  device: cpu
+  rawDeploymentMode: true
+  secret:
+    enabled: true
+    hf_token: ""
+  models:
+    llama-3-2-1b-instruct:
+      enabled: true
+      resources:
+        limits:
+          cpu: "4"
+          memory: 8Gi
+        requests:
+          cpu: "2"
+          memory: 4Gi
+
+ogx-ai:
+  # ingestion-pipeline expects the OGX service at http://llamastack:8321
+  fullnameOverride: llamastack
+  pgvector:
+    enabled: true
+  toolRuntime:
+    braveSearch:
+      enabled: false
+    tavilySearch:
+      enabled: false
+    modelContextProtocol:
+      enabled: false
+  toolGroups:
+    websearch:
+      enabled: false
+  models:
+    llama-3-2-1b-instruct:
+      enabled: true
+
+pgvector:
+  enabled: true
+  secret:
+    user: postgres
+    password: ogx_test_password
+    dbname: ogx_test
+    host: pgvector
+    port: "5432"
+
+configure-pipeline:
+  enabled: true
+  notebook:
+    create: false
+  pipelineStorage:
+    deployMinio: true
+  minio:
+    secret:
+      user: minio_rag_user
+      password: minio_rag_password
+      host: minio
+      port: "9000"
+
+ingestion-pipeline:
+  enabled: true
+  serviceAccount:
+    create: true
+    name: ogx-test-pipeline
+  pipelines:
+    # Single public GitHub docs folder — no MinIO document bucket required.
+    smoke-github:
+      enabled: true
+      source: GITHUB
+      embedding_model: all-MiniLM-L6-v2
+      name: ogx-test-kb
+      version: "1.0"
+      vector_store_name: ogx-test-kb-v1-0
+      GITHUB:
+        url: https://github.com/rh-ai-quickstart/RAG.git
+        path: docs
+        token: ""
+        branch: main

--- a/ogx-ai/tests/values.yaml
+++ b/ogx-ai/tests/values.yaml
@@ -40,8 +40,7 @@ llm-service:
           memory: 4Gi
 
 ogx-ai:
-  # ingestion-pipeline expects the OGX service at http://llamastack:8321
-  fullnameOverride: llamastack
+  fullnameOverride: ogx-ai
   pgvector:
     enabled: true
   toolRuntime:

--- a/pgvector/README.md
+++ b/pgvector/README.md
@@ -555,6 +555,9 @@ spec:
           app: llama-stack
     - podSelector:
         matchLabels:
+          app: ogx-ai
+    - podSelector:
+        matchLabels:
           app: ingestion-pipeline
     ports:
     - protocol: TCP
@@ -592,7 +595,7 @@ oc delete secret pgvector
 
 This chart integrates with:
 
-- **LlamaStack**: Vector storage for embeddings and agent memory
+- **LlamaStack / OGX**: Vector storage for embeddings and agent memory
 - **Ingestion Pipeline**: Document embedding storage
 - **Configure Pipeline**: Configuration and metadata storage
 - **AI Applications**: Vector similarity search and retrieval


### PR DESCRIPTION
## Summary

Introduces a new **ogx-ai** Helm chart as the recommended orchestration layer for [OGX](https://github.com/ogx-ai/ogx) (formerly Llama Stack), while keeping the existing **llama-stack** chart for backwards compatibility. Updates related charts and docs so the broader AI architecture can deploy and test against OGX.

### New: `ogx-ai` Helm chart (`ogx-ai/helm`)

- Deploys OGX (`ogxai/distribution-starter:1.0.2`) as an OpenAI-compatible agentic API server on port `8321`
- OGX 1.x configuration: `responses` provider, `/v1/moderations`-based guardrails via `MODERATION_ENDPOINT` (replaces Safety/Shields APIs)
- PGVector integration, MCP/tool runtime support, model auto-discovery for llm-service predictors
- OpenShift Route support, health probes on `/v1/health`, and `enableServiceLinks: false` to avoid `OGX_PORT` env collisions
- Chart version **0.8.6** with comprehensive README

### New: Integration test umbrella chart (`ogx-ai/tests`)

- End-to-end smoke test deploying **ogx-ai**, **llm-service** (Llama 3.2 1B Instruct on CPU), **pgvector**, **configure-pipeline**, and **ingestion-pipeline**
- Optional trimmed-down RAG blueprint for validating OGX + ingestion on OpenShift AI / DSP
- Documents install paths for CPU, GPU, and ogx-ai-only (no ingestion) scenarios

### Cross-chart updates

- **configure-pipeline**: Adds `OGX_AI_BASE_URL` to RAG pipeline secrets and notebook env vars (`http://ogx-ai.<ns>.svc.cluster.local:8321`)
- **ingestion-pipeline**: Adds `clientDependency` value (`llama-stack` | `ogx-ai`), propagates `CLIENT_DEPENDENCY` into KFP store tasks, and adds `ogx-client==0.1.0` alongside `llama-stack-client`
- **Docs**: Root README, VERSIONING.md, and component READMEs updated to reference OGX as the preferred path for new deployments

### Backwards compatibility

- **llama-stack** chart is unchanged functionally and remains available
- Ingestion pipeline defaults to `clientDependency: llama-stack`
- Service naming note: default Kubernetes service is `ogx-ai`; charts/jobs still targeting `llamastack` can set `fullnameOverride: llamastack` until references are migrated

## Motivation

OGX is the successor to Llama Stack. This PR gives the repo a first-class deployment path for OGX without breaking existing llama-stack-based stacks, and adds a reproducible integration test for validating the migration on OpenShift.

## Test plan

- [ ] `helm lint ogx-ai/helm`
- [ ] `helm dependency update ogx-ai/tests && helm template ogx-ai-test ogx-ai/tests --set llm-service.secret.hf_token=test`
- [ ] Deploy integration test chart on OpenShift AI cluster with valid HuggingFace token
- [ ] Verify `ogx-ai` pod becomes Ready and `/v1/health` responds
- [ ] Verify llm-service InferenceService serves `llama-3-2-1b-instruct`
- [ ] Verify ingestion smoke pipeline completes with `clientDependency: ogx-ai`
- [ ] Confirm existing llama-stack deployments are unaffected (default ingestion `clientDependency: llama-stack`)
- [ ] Confirm configure-pipeline notebook receives both `LLAMASTACK_BASE_URL` and `OGX_AI_BASE_URL`

## Notes for reviewers

- **31 files changed**, ~2,059 insertions — most of the diff is the new `ogx-ai/README.md` and Helm templates
- OGX and llama-stack are typically deployed **one or the other**, not both
- Umbrella-chart example in root README shows how to swap `llama-stack` for `ogx-ai` in a full-stack install