### PR TITLE
Add externalDatabase support to avoid duplicate postg…

### DIFF
--- a/pgvector/helm/Chart.yaml
+++ b/pgvector/helm/Chart.yaml
@@ -15,10 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7
+# Bumped to 0.5.8 for externalDatabase support
+version: 0.5.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.7"
+appVersion: "0.5.8"

--- a/pgvector/helm/Chart.yaml
+++ b/pgvector/helm/Chart.yaml
@@ -15,11 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-# Bumped to 0.5.8 for externalDatabase support
 version: 0.5.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.8"
+appVersion: "0.5.7"

--- a/pgvector/helm/templates/configmap.yaml
+++ b/pgvector/helm/templates/configmap.yaml
@@ -10,33 +10,38 @@ data:
     #!/bin/bash
     set -eo pipefail
 
-    PGHOST="${PGHOST:-127.0.0.1}"
-    PGPORT="${PGPORT:-${POSTGRES_PORT}}"
-
-    DB_EXISTS=$(psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -tc \
-      "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_DBNAME'" | tr -d '[:space:]')
-    if [ "$DB_EXISTS" != "1" ]; then
-      psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -c "CREATE DATABASE $POSTGRES_DBNAME;"
+    # When PGHOST is set (external mode via Job), use TCP with -h/-p flags.
+    # When unset (default StatefulSet mode), omit them so psql uses Unix sockets,
+    # which is required during PostgreSQL's initdb phase (listen_addresses='').
+    CONN_ARGS="-U $POSTGRES_USER"
+    if [ -n "$PGHOST" ]; then
+      CONN_ARGS="$CONN_ARGS -h $PGHOST -p $PGPORT"
     fi
 
-    EXT_EXISTS=$(psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -d "$POSTGRES_DBNAME" -tc \
+    DB_EXISTS=$(psql $CONN_ARGS -tc \
+      "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_DBNAME'" | tr -d '[:space:]')
+    if [ "$DB_EXISTS" != "1" ]; then
+      psql $CONN_ARGS -c "CREATE DATABASE $POSTGRES_DBNAME;"
+    fi
+
+    EXT_EXISTS=$(psql $CONN_ARGS -d "$POSTGRES_DBNAME" -tc \
       "SELECT 1 FROM pg_extension WHERE extname = 'vector'" | tr -d '[:space:]')
     if [ "$EXT_EXISTS" != "1" ]; then
-      psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -d "$POSTGRES_DBNAME" -c "CREATE EXTENSION VECTOR;"
+      psql $CONN_ARGS -d "$POSTGRES_DBNAME" -c "CREATE EXTENSION VECTOR;"
     fi
   {{- range .Values.extraDatabases }}
 
-    DB_EXISTS=$(psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -tc \
+    DB_EXISTS=$(psql $CONN_ARGS -tc \
       "SELECT 1 FROM pg_database WHERE datname = '{{ .name }}'" | tr -d '[:space:]')
     if [ "$DB_EXISTS" != "1" ]; then
-      psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -c "CREATE DATABASE {{ .name }};"
+      psql $CONN_ARGS -c "CREATE DATABASE {{ .name }};"
     fi
     {{- if .vectordb }}
 
-    EXT_EXISTS=$(psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -d "{{ .name }}" -tc \
+    EXT_EXISTS=$(psql $CONN_ARGS -d "{{ .name }}" -tc \
       "SELECT 1 FROM pg_extension WHERE extname = 'vector'" | tr -d '[:space:]')
     if [ "$EXT_EXISTS" != "1" ]; then
-      psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -d "{{ .name }}" -c "CREATE EXTENSION VECTOR;"
+      psql $CONN_ARGS -d "{{ .name }}" -c "CREATE EXTENSION VECTOR;"
     fi
     {{- end }}
   {{- end }}

--- a/pgvector/helm/templates/configmap.yaml
+++ b/pgvector/helm/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.externalDatabase.enabled }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -17,3 +18,5 @@ data:
     psql -U postgres -d {{ .name }} -c "CREATE EXTENSION VECTOR;"
     {{- end }}
   {{- end }}
+{{- end }}
+

--- a/pgvector/helm/templates/configmap.yaml
+++ b/pgvector/helm/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   init-db.sh: |
     #!/bin/bash
-    set -e
+    set -eo pipefail
 
     PGHOST="${PGHOST:-127.0.0.1}"
     PGPORT="${PGPORT:-${POSTGRES_PORT}}"

--- a/pgvector/helm/templates/configmap.yaml
+++ b/pgvector/helm/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.externalDatabase.enabled }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -10,13 +9,34 @@ data:
   init-db.sh: |
     #!/bin/bash
     set -e
-    psql -U postgres -c "CREATE DATABASE ${POSTGRES_DBNAME};"
-    psql -U postgres -d ${POSTGRES_DBNAME} -c "CREATE EXTENSION VECTOR;"
+
+    PGHOST="${PGHOST:-127.0.0.1}"
+    PGPORT="${PGPORT:-${POSTGRES_PORT}}"
+
+    DB_EXISTS=$(psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -tc \
+      "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_DBNAME'" | tr -d '[:space:]')
+    if [ "$DB_EXISTS" != "1" ]; then
+      psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -c "CREATE DATABASE $POSTGRES_DBNAME;"
+    fi
+
+    EXT_EXISTS=$(psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -d "$POSTGRES_DBNAME" -tc \
+      "SELECT 1 FROM pg_extension WHERE extname = 'vector'" | tr -d '[:space:]')
+    if [ "$EXT_EXISTS" != "1" ]; then
+      psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -d "$POSTGRES_DBNAME" -c "CREATE EXTENSION VECTOR;"
+    fi
   {{- range .Values.extraDatabases }}
-    psql -U postgres -c "CREATE DATABASE {{ .name }};"
+
+    DB_EXISTS=$(psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -tc \
+      "SELECT 1 FROM pg_database WHERE datname = '{{ .name }}'" | tr -d '[:space:]')
+    if [ "$DB_EXISTS" != "1" ]; then
+      psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -c "CREATE DATABASE {{ .name }};"
+    fi
     {{- if .vectordb }}
-    psql -U postgres -d {{ .name }} -c "CREATE EXTENSION VECTOR;"
+
+    EXT_EXISTS=$(psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -d "{{ .name }}" -tc \
+      "SELECT 1 FROM pg_extension WHERE extname = 'vector'" | tr -d '[:space:]')
+    if [ "$EXT_EXISTS" != "1" ]; then
+      psql -U "$POSTGRES_USER" -h "$PGHOST" -p "$PGPORT" -d "{{ .name }}" -c "CREATE EXTENSION VECTOR;"
+    fi
     {{- end }}
   {{- end }}
-{{- end }}
-

--- a/pgvector/helm/templates/init-job.yaml
+++ b/pgvector/helm/templates/init-job.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         {{- include "pgvector.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: OnFailure
       containers:
         - name: init-db

--- a/pgvector/helm/templates/init-job.yaml
+++ b/pgvector/helm/templates/init-job.yaml
@@ -10,6 +10,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  activeDeadlineSeconds: 300
   backoffLimit: 5
   template:
     metadata:

--- a/pgvector/helm/templates/init-job.yaml
+++ b/pgvector/helm/templates/init-job.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.externalDatabase.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "pgvector.fullname" . }}-init
+  namespace: {{ include "pgvector.namespace" . }}
+  labels:
+    {{- include "pgvector.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      labels:
+        {{- include "pgvector.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: init-db
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["/bin/bash", "/scripts/init-db.sh"]
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgvector.fullname" . }}
+                  key: user
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgvector.fullname" . }}
+                  key: password
+            - name: POSTGRES_DBNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgvector.fullname" . }}
+                  key: dbname
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgvector.fullname" . }}
+                  key: host
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgvector.fullname" . }}
+                  key: port
+          volumeMounts:
+            - name: initdb-volume
+              mountPath: /scripts
+      volumes:
+        - name: initdb-volume
+          configMap:
+            name: {{ include "pgvector.fullname" . }}-initsql
+{{- end }}

--- a/pgvector/helm/templates/init-job.yaml
+++ b/pgvector/helm/templates/init-job.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "pgvector.namespace" . }}
   labels:
     {{- include "pgvector.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 5
   template:

--- a/pgvector/helm/templates/secret.yaml
+++ b/pgvector/helm/templates/secret.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.externalDatabase.enabled (not .Values.secret.create) }}
+{{- fail "secret.create must be true when externalDatabase.enabled=true (the init Job requires the Secret)" }}
+{{- end }}
 {{- if .Values.secret.create }}
 {{- if .Values.externalDatabase.enabled }}
 {{- $_ := required "externalDatabase.host is required when externalDatabase.enabled=true" .Values.externalDatabase.host }}

--- a/pgvector/helm/templates/secret.yaml
+++ b/pgvector/helm/templates/secret.yaml
@@ -1,4 +1,9 @@
 {{- if .Values.secret.create }}
+{{- $user := ternary .Values.externalDatabase.user .Values.secret.user .Values.externalDatabase.enabled }}
+{{- $password := ternary .Values.externalDatabase.password .Values.secret.password .Values.externalDatabase.enabled }}
+{{- $host := ternary .Values.externalDatabase.host .Values.secret.host .Values.externalDatabase.enabled }}
+{{- $port := ternary (.Values.externalDatabase.port | toString) (.Values.secret.port | toString) .Values.externalDatabase.enabled }}
+{{- $dbname := ternary .Values.externalDatabase.dbname .Values.secret.dbname .Values.externalDatabase.enabled }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -7,12 +12,17 @@ metadata:
   labels:
     {{- include "pgvector.labels" . | nindent 4 }}
 data:
-  user: {{ .Values.secret.user | b64enc | quote }}
-  password: {{ .Values.secret.password | b64enc | quote }}
-  host: {{ .Values.secret.host | b64enc | quote }}
-  port: {{ .Values.secret.port | b64enc | quote }}
-  dbname: {{ .Values.secret.dbname | b64enc | quote }}
-  jdbc-uri: {{ printf "jdbc:postgresql://%s.%s:%s/%s?password=%s&user=%s" .Values.secret.host (include "pgvector.namespace" .) .Values.secret.port .Values.secret.dbname .Values.secret.password .Values.secret.user | b64enc | quote }}
-  uri: {{ printf "postgresql://%s:%s@%s.%s:%s/%s" .Values.secret.user .Values.secret.password .Values.secret.host (include "pgvector.namespace" .) .Values.secret.port .Values.secret.dbname | b64enc | quote }}
+  user: {{ $user | b64enc | quote }}
+  password: {{ $password | b64enc | quote }}
+  host: {{ $host | b64enc | quote }}
+  port: {{ $port | b64enc | quote }}
+  dbname: {{ $dbname | b64enc | quote }}
+  {{- if .Values.externalDatabase.enabled }}
+  jdbc-uri: {{ printf "jdbc:postgresql://%s:%s/%s?password=%s&user=%s" $host $port $dbname $password $user | b64enc | quote }}
+  uri: {{ printf "postgresql://%s:%s@%s:%s/%s" $user $password $host $port $dbname | b64enc | quote }}
+  {{- else }}
+  jdbc-uri: {{ printf "jdbc:postgresql://%s.%s:%s/%s?password=%s&user=%s" $host (include "pgvector.namespace" .) $port $dbname $password $user | b64enc | quote }}
+  uri: {{ printf "postgresql://%s:%s@%s.%s:%s/%s" $user $password $host (include "pgvector.namespace" .) $port $dbname | b64enc | quote }}
+  {{- end }}
 type: Opaque
 {{- end }}

--- a/pgvector/helm/templates/secret.yaml
+++ b/pgvector/helm/templates/secret.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.secret.create }}
+{{- if .Values.externalDatabase.enabled }}
+{{- $_ := required "externalDatabase.host is required when externalDatabase.enabled=true" .Values.externalDatabase.host }}
+{{- $_ := required "externalDatabase.user is required when externalDatabase.enabled=true" .Values.externalDatabase.user }}
+{{- $_ := required "externalDatabase.password is required when externalDatabase.enabled=true" .Values.externalDatabase.password }}
+{{- $_ := required "externalDatabase.dbname is required when externalDatabase.enabled=true" .Values.externalDatabase.dbname }}
+{{- end }}
 {{- $user := ternary .Values.externalDatabase.user .Values.secret.user .Values.externalDatabase.enabled }}
 {{- $password := ternary .Values.externalDatabase.password .Values.secret.password .Values.externalDatabase.enabled }}
 {{- $host := ternary .Values.externalDatabase.host .Values.secret.host .Values.externalDatabase.enabled }}

--- a/pgvector/helm/templates/service.yaml
+++ b/pgvector/helm/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.externalDatabase.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
       name: http
   selector:
     {{- include "pgvector.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/pgvector/helm/templates/statefulset.yaml
+++ b/pgvector/helm/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.externalDatabase.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -91,3 +92,4 @@ spec:
         - name: initdb-volume
           configMap:
             name: {{ include "pgvector.fullname" . }}-initsql
+{{- end }}

--- a/pgvector/helm/values.yaml
+++ b/pgvector/helm/values.yaml
@@ -92,3 +92,14 @@ secret:
 extraDatabases: []
   #- name: test_db
   #  vectordb: false
+
+# External database configuration
+# When enabled, the chart will NOT deploy a PostgreSQL instance.
+# Instead, it will create a Secret pointing to the external database.
+externalDatabase:
+  enabled: false
+  host: ""
+  port: "5432"
+  user: ""
+  password: ""
+  dbname: ""


### PR DESCRIPTION
Summary

This PR adds an externalDatabase option to the pgvector chart to avoid duplicate PostgreSQL deployments. When multiple charts include pgvector as a subchart, each deploys its own PostgreSQL instance, causing conflicts. With externalDatabase.enabled=true, consumers can point to an already-running pgvector instead of deploying a new one.

Changes

- When externalDatabase.enabled=true, the chart skips the StatefulSet and Service, but still creates:
- Secret — with external connection details
- ConfigMap — with an idempotent init script that checks if the database and vector extension exist before creating them
- Job — runs the init script against the external PostgreSQL instance, with Helm hook annotations (post-install,post-upgrade) for lifecycle management, activeDeadlineSeconds: 300 to bound execution time, and imagePullSecrets support for private registries
- Made the init script idempotent — checks pg_database and pg_extension before creating, so it is safe to run on both helm install and helm upgrade
- Init script uses Unix sockets in default (StatefulSet) mode and TCP only in external mode, matching PostgreSQL's initdb behavior (listen_addresses='')
- Added set -eo pipefail so psql failures in piped commands are caught immediately
- Added required validation for external database fields (host, user, password, dbname) so helm install fails early with a clear error
- Added fail guard preventing secret.create=false with externalDatabase.enabled=true since the init Job depends on the Secret
- Bumped chart version to 0.5.8

---
Test 1: Default mode (externalDatabase.enabled=false)

Install:
```
kubectl create namespace pgvector-test

helm install pgvector-test pgvector/helm/ \
--namespace pgvector-test
```
Verify resources:
```
$ kubectl get secret pgvector -n pgvector-test
NAME       TYPE     DATA   AGE
pgvector   Opaque   7      62s

$ kubectl get configmap pgvector-initsql -n pgvector-test
NAME               DATA   AGE
pgvector-initsql   1      62s

$ kubectl get statefulset pgvector -n pgvector-test
NAME       READY   AGE
pgvector   1/1     62s

$ kubectl get service pgvector -n pgvector-test
NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
pgvector   ClusterIP   172.30.219.3   <none>        5432/TCP   62s

$ kubectl get job pgvector-init -n pgvector-test
Error from server (NotFound): jobs.batch "pgvector-init" not found

$ kubectl get pods -n pgvector-test
NAME         READY   STATUS    RESTARTS   AGE
pgvector-0   1/1     Running   0          63s
```

Verify database and extension:
```
$ kubectl exec pgvector-0 -n pgvector-test -- psql -U postgres -tc \
"SELECT datname FROM pg_database WHERE datname = 'rag_blueprint'"
rag_blueprint

$ kubectl exec pgvector-0 -n pgvector-test -- psql -U postgres -d rag_blueprint -tc \
"SELECT extname FROM pg_extension WHERE extname = 'vector'"
vector
```

Result: All resources created. Pod running with zero restarts. Database and vector extension created successfully.

Cleanup:
```
helm uninstall pgvector-test -n pgvector-test
```

---
Test 2: External mode (externalDatabase.enabled=true)

Install:
```
helm install pgvector-test pgvector/helm/ \
--namespace pgvector-test \
--set externalDatabase.enabled=true \
--set externalDatabase.host=my-external-pg.example.com \
--set externalDatabase.port=5432 \
--set externalDatabase.user=admin \
--set externalDatabase.password=secret123 \
--set externalDatabase.dbname=keycloak
```
Verify:
```
$ kubectl get secret pgvector -n pgvector-test
NAME       TYPE     DATA   AGE
pgvector   Opaque   7      40s

$ kubectl get configmap pgvector-initsql -n pgvector-test
NAME               DATA   AGE
pgvector-initsql   1      40s

$ kubectl get job pgvector-init -n pgvector-test
NAME            STATUS    COMPLETIONS   DURATION   AGE
pgvector-init   Running   0/1           39s        39s

$ kubectl get statefulset pgvector -n pgvector-test
Error from server (NotFound): statefulsets.apps "pgvector" not found

$ kubectl get service pgvector -n pgvector-test
Error from server (NotFound): services "pgvector" not found
```

Result: `Secret`, `ConfigMap`, and init Job created. No StatefulSet or Service deployed. The init Job connects to the external PostgreSQL, checks if the database exists, and creates it only if missing. The init script is idempotent and safe to run on both helm install and helm upgrade.

Cleanup:
```
helm uninstall pgvector-test -n pgvector-test
kubectl delete namespace pgvector-test
```

---
Test 3: Input validation
```
$ helm template test pgvector/helm/ \
--set secret.create=false \
--set externalDatabase.enabled=true \
--set externalDatabase.host=my-host \
--set externalDatabase.user=admin \
--set externalDatabase.password=secret123 \
--set externalDatabase.dbname=mydb
Error: execution error at (pgvector/templates/secret.yaml:2:4):
secret.create must be true when externalDatabase.enabled=true (the init Job requires the Secret)

$ helm template test pgvector/helm/ \
--set externalDatabase.enabled=true \
--set externalDatabase.user=admin \
--set externalDatabase.password=secret123 \
--set externalDatabase.dbname=mydb
Error: execution error at (pgvector/templates/secret.yaml:6:10):
externalDatabase.host is required when externalDatabase.enabled=true

$ helm template test pgvector/helm/ \
--set externalDatabase.enabled=true \
--set externalDatabase.host=my-host \
--set externalDatabase.user=admin \
--set externalDatabase.dbname=mydb
Error: execution error at (pgvector/templates/secret.yaml:8:10):
externalDatabase.password is required when externalDatabase.enabled=true
```
Result: Invalid configurations fail at helm install time with clear error messages.

---
Known limitation

Passwords containing @, :, ?, or & will break the uri and jdbc-uri Secret fields since they are interpolated directly without URL-encoding. This is a pre-existing issue that predates this PR and will be tracked as a separate follow-up.