### PR TITLE
fix(playground): namespace MCP ConfigMap name to avoid multi-tenant collisions

### DIFF
--- a/playground/helm/Chart.yaml
+++ b/playground/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: playground
 description: RHOAI Gen AI Studio Playground quickstart — registers hub-deployed MCP servers and vector stores with the Playground UI.
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "3.4"

--- a/playground/helm/templates/mcp-servers-configmap.yaml
+++ b/playground/helm/templates/mcp-servers-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gen-ai-aa-mcp-servers
+  name: gen-ai-aa-mcp-servers-{{ .Release.Namespace }}
   namespace: {{ .Values.mcpServers.namespace | default "redhat-ods-applications" }}
   labels:
     {{- include "playground.labels" . | nindent 4 }}

--- a/playground/helm/values.yaml
+++ b/playground/helm/values.yaml
@@ -33,7 +33,7 @@ notebookController:
   enabled: false
 
 # ── MCP Server Registration ──────────────────────────────────────
-# Creates a ConfigMap (gen-ai-aa-mcp-servers) in redhat-ods-applications
+# Creates a ConfigMap (gen-ai-aa-mcp-servers-<namespace>) in redhat-ods-applications
 # that registers existing MCP server endpoints with the Playground UI.
 # Each entry becomes a data key in the ConfigMap (name → JSON value).
 # No new deployments are created — this points to already-deployed services.


### PR DESCRIPTION
## Problem

The MCP servers ConfigMap (`gen-ai-aa-mcp-servers`) is created in
`redhat-ods-applications` with a fixed name. When multiple quickstarts deploy
a playground to the same cluster, the second deployment fails with:

> ConfigMap "gen-ai-aa-mcp-servers" in namespace "redhat-ods-applications"
> exists and cannot be imported into the current release: invalid ownership metadata

This is because Helm enforces release ownership on resources - a ConfigMap
created by one release cannot be adopted by another.

## Fix

Suffix the ConfigMap name with the release namespace:

`gen-ai-aa-mcp-servers` → `gen-ai-aa-mcp-servers-{{ .Release.Namespace }}`

Each quickstart now gets its own uniquely-named ConfigMap in
`redhat-ods-applications`, avoiding ownership conflicts.

## Testing

Deployed the chart to two separate namespaces on the same cluster:
- Without fix: second deploy fails immediately with ownership error
- With fix: both deploy successfully, each creating its own ConfigMap
  (`gen-ai-aa-mcp-servers-test-playground-a`, `gen-ai-aa-mcp-servers-test-playground-b`)

## Notes

- The custom-endpoints and vector-stores ConfigMaps already deploy to the
  release namespace (not `redhat-ods-applications`), so they don't have this
  issue.
- Chart version bumped to 0.0.2.